### PR TITLE
Add FuseSoC support for building verilator model

### DIFF
--- a/ariane.core
+++ b/ariane.core
@@ -1,0 +1,72 @@
+CAPI=2:
+name : ::ariane:0
+
+filesets:
+  rtl:
+    files:
+      - include/ariane_pkg.sv
+      - include/nbdcache_pkg.sv
+      - src/alu.sv
+      - src/ariane.sv
+      - src/ariane_wrapped.sv
+      - src/branch_unit.sv
+      - src/btb.sv
+      - src/cache_ctrl.sv
+      - src/commit_stage.sv
+      - src/compressed_decoder.sv
+      - src/controller.sv
+      - src/csr_buffer.sv
+      - src/csr_regfile.sv
+      - src/debug_unit.sv
+      - src/decoder.sv
+      - src/ex_stage.sv
+      - src/fetch_fifo.sv
+      - src/fifo.sv
+      - src/icache.sv
+      - src/id_stage.sv
+      - src/if_stage.sv
+      - src/instr_realigner.sv
+      - src/issue_read_operands.sv
+      - src/issue_stage.sv
+      - src/lfsr.sv
+      - src/load_unit.sv
+      - src/lsu_arbiter.sv
+      - src/lsu.sv
+      - src/miss_handler.sv
+      - src/mmu.sv
+      - src/mult.sv
+      - src/nbdcache.sv
+      - src/pcgen_stage.sv
+      - src/perf_counters.sv
+      - src/ptw.sv
+      - src/regfile_ff.sv
+      - src/scoreboard.sv
+      - src/store_buffer.sv
+      - src/store_unit.sv
+      - src/tlb.sv
+    file_type : systemVerilogSource
+    depend :
+      - pulp-platform.org::axi_mem_if
+      - tool_verilator? (pulp-platform::uvm-components)
+  behav_sram:
+    files:
+      - src/util/behav_sram.sv
+    file_type : systemVerilogSource
+    
+targets:
+  verilator:
+    default_tool : verilator
+    filesets: [behav_sram, rtl]
+    tools:
+      verilator:
+        mode : cc
+        verilator_options :
+          - --unroll-count 256
+          - -Wno-fatal
+          - -LDFLAGS
+          - "-lfesvr"
+          - -CFLAGS
+          - "-std=c++11"
+          - -Wall
+          - --trace
+    toplevel : [ariane_wrapped]


### PR DESCRIPTION
This adds FuseSoC support for building and running the verilator model of Ariane (a.k.a. Saturn-V). Before this works, it needs FuseSoC support for the core dependencies (https://github.com/pulp-platform/axi_mem_if/pull/1 and https://github.com/pulp-platform/uvm-components/pull/1)

Once this is done, the FuseSoC support can be tested by first creating a workspace directory and register the libraries by running

    fusesoc library add axi_mem_if https://github.com/pulp-platform/axi_mem_if
    fusesoc library add uvm-components https://github.com/pulp-platform/uvm-components
    fusesoc library add ariane https://github.com/pulp-platform/ariane

or, alternatively if the repos are already on disk and you want to use those instead, add

    [library.axi_mem_if]
    location = /path/to/repo

    [library.uvm-components]
    location = /path/to/repo

    [library.ariane]
    location = /path/to/repo

If all repos exist under a common directory it's enough to add

    [library.pulp_cores]
    location = /path/to/parent/directory

To list all targets supported by the ariane core, run `fusesoc core-info ariane`. Currently the only supported target is verilator. To build and run a simulation in one step, use `fusesoc run --target=verilator ariane -p /path/to/elf/file`. To only build, run `fusesoc build --target=verilator ariane`. This model can then be run without rebuilding with `fusesoc run --run --target=verilator ariane -p /path/to/elf/file`