### PR TITLE
Add placeholders for PMP CSRs for memory protection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,27 +44,27 @@ src := $(wildcard src/*.sv) $(wildcard tb/common/*.sv) $(wildcard src/axi2per/*.
 tbs := tb/alu_tb.sv tb/core_tb.sv tb/dcache_arbiter_tb.sv tb/store_queue_tb.sv tb/scoreboard_tb.sv tb/fifo_tb.sv
 
 # RISCV-tests path
-riscv-test-dir := $(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa
+riscv-test-dir := tmp/riscv-tests/build/isa
 riscv-tests := rv64ui-p-add rv64ui-p-addi rv64ui-p-slli rv64ui-p-addiw rv64ui-p-addw rv64ui-p-and rv64ui-p-auipc 			 \
 			   rv64ui-p-beq rv64ui-p-bge rv64ui-p-bgeu rv64ui-p-andi rv64ui-p-blt rv64ui-p-bltu rv64ui-p-bne                 \
 			   rv64ui-p-simple rv64ui-p-jal rv64ui-p-jalr rv64ui-p-or rv64ui-p-ori rv64ui-p-sub rv64ui-p-subw                \
-			   rv64ui-p-xor rv64ui-p-xori rv64ui-p-slliw rv64ui-p-sll rv64ui-p-slli rv64ui-p-sllw 							 \
-			   rv64ui-p-slt rv64ui-p-slti rv64ui-p-sltiu rv64ui-p-sltu rv64ui-p-sra rv64ui-p-srai 							 \
-			   rv64ui-p-sraiw rv64ui-p-sraw rv64ui-p-srl rv64ui-p-srli rv64ui-p-srliw rv64ui-p-srlw 						 \
-			   rv64ui-p-lb rv64ui-p-lbu rv64ui-p-ld rv64ui-p-lh rv64ui-p-lhu rv64ui-p-lui rv64ui-p-lw rv64ui-p-lwu 			 \
+			   rv64ui-p-xor rv64ui-p-xori rv64ui-p-slliw rv64ui-p-sll rv64ui-p-slli rv64ui-p-sllw 				 \
+			   rv64ui-p-slt rv64ui-p-slti rv64ui-p-sltiu rv64ui-p-sltu rv64ui-p-sra rv64ui-p-srai 				 \
+			   rv64ui-p-sraiw rv64ui-p-sraw rv64ui-p-srl rv64ui-p-srli rv64ui-p-srliw rv64ui-p-srlw 			 \
+			   rv64ui-p-lb rv64ui-p-lbu rv64ui-p-ld rv64ui-p-lh rv64ui-p-lhu rv64ui-p-lui rv64ui-p-lw rv64ui-p-lwu 		 \
 			   rv64mi-p-csr rv64mi-p-mcsr rv64mi-p-illegal rv64mi-p-ma_addr rv64mi-p-ma_fetch rv64mi-p-sbreak rv64mi-p-scall \
-			   rv64si-p-csr rv64si-p-ma_fetch rv64si-p-scall rv64si-p-wfi rv64si-p-sbreak rv64si-p-dirty  					 \
-			   rv64uc-p-rvc																									 \
-			   rv64ui-v-add rv64ui-v-addi rv64ui-p-slli rv64ui-v-addiw rv64ui-v-addw rv64ui-v-and rv64ui-v-auipc			 \
-			   rv64ui-v-beq rv64ui-v-bge rv64ui-v-bgeu rv64ui-v-andi rv64ui-v-blt rv64ui-v-bltu rv64ui-v-bne 				 \
-			   rv64ui-v-simple rv64ui-v-jal rv64ui-v-jalr rv64ui-v-or rv64ui-v-ori rv64ui-v-sub rv64ui-v-subw				 \
-   			   rv64ui-v-xor rv64ui-v-xori rv64ui-v-slliw rv64ui-v-sll rv64ui-v-slli rv64ui-v-slliw 							 \
-			   rv64ui-v-slt rv64ui-v-slti rv64ui-v-sltiu rv64ui-v-sltu rv64ui-v-sra rv64ui-v-srai 					         \
-			   rv64ui-v-sraiw rv64ui-v-sraw rv64ui-v-srl rv64ui-v-srli rv64ui-v-srliw rv64ui-v-srlw  						 \
-			   rv64ui-v-lb rv64ui-v-lbu rv64ui-v-ld rv64ui-v-lh rv64ui-v-lhu rv64ui-v-lui 								     \
-			   rv64um-p-mul rv64um-p-mulh rv64um-p-mulhsu rv64um-p-mulhu rv64um-p-div rv64um-p-divu rv64um-p-rem  		 	 \
-			   rv64um-p-remu rv64um-p-mulw rv64um-p-divw rv64um-p-divuw rv64um-p-remw rv64um-p-remuw 						 \
-			   rv64um-v-mul rv64um-v-mulh rv64um-v-mulhsu rv64um-v-mulhu rv64um-v-div rv64um-v-divu rv64um-v-rem    		 \
+			   rv64si-p-csr rv64si-p-ma_fetch rv64si-p-scall rv64si-p-wfi rv64si-p-sbreak rv64si-p-dirty  			 \
+			   rv64uc-p-rvc													 \
+			   rv64ui-v-add rv64ui-v-addi rv64ui-p-slli rv64ui-v-addiw rv64ui-v-addw rv64ui-v-and rv64ui-v-auipc		 \
+			   rv64ui-v-beq rv64ui-v-bge rv64ui-v-bgeu rv64ui-v-andi rv64ui-v-blt rv64ui-v-bltu rv64ui-v-bne 		 \
+			   rv64ui-v-simple rv64ui-v-jal rv64ui-v-jalr rv64ui-v-or rv64ui-v-ori rv64ui-v-sub rv64ui-v-subw		 \
+			   rv64ui-v-xor rv64ui-v-xori rv64ui-v-slliw rv64ui-v-sll rv64ui-v-slli rv64ui-v-slliw 				 \
+			   rv64ui-v-slt rv64ui-v-slti rv64ui-v-sltiu rv64ui-v-sltu rv64ui-v-sra rv64ui-v-srai 			         \
+			   rv64ui-v-sraiw rv64ui-v-sraw rv64ui-v-srl rv64ui-v-srli rv64ui-v-srliw rv64ui-v-srlw  			 \
+			   rv64ui-v-lb rv64ui-v-lbu rv64ui-v-ld rv64ui-v-lh rv64ui-v-lhu rv64ui-v-lui 					 \
+			   rv64um-p-mul rv64um-p-mulh rv64um-p-mulhsu rv64um-p-mulhu rv64um-p-div rv64um-p-divu rv64um-p-rem  		 \
+			   rv64um-p-remu rv64um-p-mulw rv64um-p-divw rv64um-p-divuw rv64um-p-remw rv64um-p-remuw 			 \
+			   rv64um-v-mul rv64um-v-mulh rv64um-v-mulhsu rv64um-v-mulhu rv64um-v-div rv64um-v-divu rv64um-v-rem    	 \
 			   rv64um-v-remu rv64um-v-mulw rv64um-v-divw rv64um-v-divuw rv64um-v-remw rv64um-v-remuw
 
 # failed test directory
@@ -175,7 +175,7 @@ $(tests): build
 verilate:
 	$(verilator) $(ariane_pkg) $(filter-out src/regfile.sv, $(wildcard src/*.sv)) $(wildcard src/axi_slice/*.sv) \
 	src/util/cluster_clock_gating.sv src/util/behav_sram.sv src/axi_mem_if/axi2mem.sv tb/agents/axi_if/axi_if.sv \
-	--unroll-count 256 -Wno-fatal -LDFLAGS "-lfesvr" -CFLAGS "-std=c++11 -I$(RISCV)/include" -Wall --cc --trace \
+	--unroll-count 256 -Wno-fatal -LDFLAGS "-lfesvr" -CFLAGS "-std=c++11" -Wall --cc --trace \
 	$(list_incdir) --top-module ariane_wrapped --exe tb/ariane_tb.cpp tb/simmem.cpp
 	cd obj_dir && make -j8 -f Variane_wrapped.mk
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ src := $(wildcard src/*.sv) $(wildcard tb/common/*.sv) $(wildcard src/axi2per/*.
 tbs := tb/alu_tb.sv tb/core_tb.sv tb/dcache_arbiter_tb.sv tb/store_queue_tb.sv tb/scoreboard_tb.sv tb/fifo_tb.sv
 
 # RISCV-tests path
-riscv-test-dir := tmp/riscv-tests/build/isa
+riscv-test-dir := $(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa
 riscv-tests := rv64ui-p-add rv64ui-p-addi rv64ui-p-slli rv64ui-p-addiw rv64ui-p-addw rv64ui-p-and rv64ui-p-auipc 			 \
 			   rv64ui-p-beq rv64ui-p-bge rv64ui-p-bgeu rv64ui-p-andi rv64ui-p-blt rv64ui-p-bltu rv64ui-p-bne                 \
 			   rv64ui-p-simple rv64ui-p-jal rv64ui-p-jalr rv64ui-p-or rv64ui-p-ori rv64ui-p-sub rv64ui-p-subw                \
@@ -175,7 +175,7 @@ $(tests): build
 verilate:
 	$(verilator) $(ariane_pkg) $(filter-out src/regfile.sv, $(wildcard src/*.sv)) $(wildcard src/axi_slice/*.sv) \
 	src/util/cluster_clock_gating.sv src/util/behav_sram.sv src/axi_mem_if/axi2mem.sv tb/agents/axi_if/axi_if.sv \
-	--unroll-count 256 -Wno-fatal -LDFLAGS "-lfesvr" -CFLAGS "-std=c++11" -Wall --cc --trace \
+	--unroll-count 256 -Wno-fatal -LDFLAGS "-lfesvr" -CFLAGS "-std=c++11 -I$(RISCV)/include" -Wall --cc --trace \
 	$(list_incdir) --top-module ariane_wrapped --exe tb/ariane_tb.cpp tb/simmem.cpp
 	cd obj_dir && make -j8 -f Variane_wrapped.mk
 

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -335,6 +335,8 @@ package ariane_pkg;
         CSR_MCAUSE         = 12'h342,
         CSR_MTVAL          = 12'h343,
         CSR_MIP            = 12'h344,
+        CSR_PMPCFG0        = 12'h3A0,
+        CSR_PMPADDR0       = 12'h3B0,
         CSR_MVENDORID      = 12'hF11,
         CSR_MARCHID        = 12'hF12,
         CSR_MIMPID         = 12'hF13,

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -136,6 +136,8 @@ module csr_regfile #(
     logic [63:0] medeleg_q,  medeleg_d;
     logic [63:0] mideleg_q,  mideleg_d;
     logic [63:0] mip_q,      mip_d;
+    logic [63:0] pmpcfg0_q,  pmpcfg0_d;
+    logic [63:0] pmpaddr0_q, pmpaddr0_d;
     logic [63:0] mie_q,      mie_d;
     logic [63:0] mscratch_q, mscratch_d;
     logic [63:0] mepc_q,     mepc_d;
@@ -197,7 +199,6 @@ module csr_regfile #(
                 CSR_MISA:               csr_rdata = ISA_CODE;
                 CSR_MEDELEG:            csr_rdata = medeleg_q;
                 CSR_MIDELEG:            csr_rdata = mideleg_q;
-                CSR_MIP:                csr_rdata = mip_q;
                 CSR_MIE:                csr_rdata = mie_q;
                 CSR_MTVEC:              csr_rdata = mtvec_q;
                 CSR_MCOUNTEREN:         csr_rdata = 64'b0; // not implemented
@@ -205,6 +206,10 @@ module csr_regfile #(
                 CSR_MEPC:               csr_rdata = mepc_q;
                 CSR_MCAUSE:             csr_rdata = mcause_q;
                 CSR_MTVAL:              csr_rdata = mtval_q;
+                CSR_MIP:                csr_rdata = mip_q;
+                // Placeholders for M-mode protection
+                CSR_PMPCFG0:            csr_rdata = pmpcfg0_q;
+                CSR_PMPADDR0:           csr_rdata = pmpaddr0_q;
                 CSR_MVENDORID:          csr_rdata = 64'b0; // not implemented
                 CSR_MARCHID:            csr_rdata = 64'b0; // PULP, anonymous source (no allocated ID yet)
                 CSR_MIMPID:             csr_rdata = 64'b0; // not implemented
@@ -343,7 +348,6 @@ module csr_regfile #(
 
                 // mask the register so that unsupported interrupts can never be set
                 CSR_MIE:                mie_d       = csr_wdata & 64'hBBB; // we only support supervisor and m-mode interrupts
-                CSR_MIP:                mip_d       = mip;
 
                 CSR_MTVEC: begin
                     mtvec_d     = {csr_wdata[63:2], 1'b0, csr_wdata[0]};
@@ -358,6 +362,11 @@ module csr_regfile #(
                 CSR_MEPC:               mepc_d      = {csr_wdata[63:1], 1'b0};
                 CSR_MCAUSE:             mcause_d    = csr_wdata;
                 CSR_MTVAL:              mtval_d     = csr_wdata;
+                CSR_MIP:                mip_d       = mip;
+                // Placeholders for M-mode protection
+                CSR_PMPCFG0:            pmpcfg0_d   = csr_wdata;
+                CSR_PMPADDR0:           pmpaddr0_d  = csr_wdata;
+
                 CSR_MCYCLE:             cycle_d     = csr_wdata;
                 CSR_MINSTRET:           instret_d   = csr_wdata;
                 CSR_DCACHE:             dcache_d    = csr_wdata[0]; // enable bit

--- a/src/util/instruction_trace_item.svh
+++ b/src/util/instruction_trace_item.svh
@@ -80,6 +80,8 @@ class instruction_trace_item;
             CSR_MCAUSE:     return "mcause";
             CSR_MTVAL:      return "mtval";
             CSR_MIP:        return "mip";
+            CSR_PMPCFG0:    return "pmpcfg0";
+            CSR_PMPADDR0:   return "pmpaddr0";
             CSR_MVENDORID:  return "mvendorid";
             CSR_MARCHID:    return "marchid";
             CSR_MIMPID:     return "mimpid";

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,37 @@
+# This script emulates what travis check in test does on the public server
+# comment out next command if you don't want to use sudo
+sudo apt install \
+      gcc-4.8 \
+      g++-4.8 \
+      gperf \
+      autoconf \
+      automake \
+      autotools-dev \
+      libmpc-dev \
+      libmpfr-dev \
+      libgmp-dev \
+      gawk \
+      build-essential \
+      bison \
+      flex \
+      texinfo \
+      python-pexpect \
+      libusb-1.0-0-dev \
+      device-tree-compiler
+# Customise this to a fast local disk
+export TOP=/local/scratch/$USER
+export TRAVIS_BUILD_DIR=$TOP/ariane-isatest
+export RISCV=$TOP/riscv_install
+export PATH=$TOP/riscv_install/bin:$TRAVIS_BUILD_DIR/tmp/bin:$PATH
+export CXX=g++-4.8 CC=gcc-4.8
+ci/make-tmp.sh
+export LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/lib
+export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/tmp/lib
+export C_INCLUDE_PATH=$TRAVIS_BUILD_DIR/tmp/include
+export CPLUS_INCLUDE_PATH=$TRAVIS_BUILD_DIR/tmp/include
+export VERILATOR_ROOT=$TRAVIS_BUILD_DIR/tmp/verilator-3.918/
+ci/build-riscv-gcc.sh
+ci/install-verilator.sh
+ci/install-fesvr.sh
+ci/build-riscv-tests.sh
+make run-asm-tests-verilator


### PR DESCRIPTION
Make ISA test path relative to $(RISCV). Add placeholder CSRs to prevent divergence when ISA tests initialise PMPs. Function needs fleshing out later. Path to fesvr/htif.h needs adding to verilator flags.
