### PR TITLE
WIP: Fix #54

### DIFF
--- a/src/miss_handler.sv
+++ b/src/miss_handler.sv
@@ -45,6 +45,7 @@ module miss_handler #(
 
     input  logic [NR_PORTS-1:0][55:0]                   mshr_addr_i,
     output logic [NR_PORTS-1:0]                         mshr_addr_matches_o,
+    output logic [NR_PORTS-1:0]                         mshr_index_matches_o,
     // Port to SRAMs, for refill and eviction
     output logic  [SET_ASSOCIATIVITY-1:0]               req_o,
     output logic  [INDEX_WIDTH-1:0]                     addr_o, // address into cache array
@@ -338,12 +339,18 @@ module miss_handler #(
     // check MSHR for aliasing
     always_comb begin
 
-        mshr_addr_matches_o = 'b0;
+        mshr_addr_matches_o  = 'b0;
+        mshr_index_matches_o = 'b0;
 
         for (int i = 0; i < NR_PORTS; i++) begin
             // check mshr for potential matching of other units, exclude the unit currently being served
             if (mshr_q.valid && mshr_addr_i[i][55:BYTE_OFFSET] == mshr_q.addr[55:BYTE_OFFSET]) begin
                 mshr_addr_matches_o[i] = 1'b1;
+            end
+
+            // same as previous, but checking only the index
+            if (mshr_q.valid && mshr_addr_i[i][INDEX_WIDTH-1:BYTE_OFFSET] == mshr_q.addr[INDEX_WIDTH-1:BYTE_OFFSET]) begin
+                mshr_index_matches_o[i] = 1'b1;
             end
         end
     end

--- a/src/nbdcache.sv
+++ b/src/nbdcache.sv
@@ -74,6 +74,7 @@ module nbdcache #(
     logic [2:0]                        busy;
     logic [2:0][55:0]                  mshr_addr;
     logic [2:0]                        mshr_addr_matches;
+    logic [2:0]                        mshr_index_matches;
     logic [63:0]                       critical_word;
     logic                              critical_word_valid;
 
@@ -143,6 +144,7 @@ module nbdcache #(
 
                 .mshr_addr_o           ( mshr_addr         [i] ), // TODO
                 .mshr_addr_matches_i   ( mshr_addr_matches [i] ), // TODO
+                .mshr_index_matches_i  ( mshr_index_matches[i] ), // TODO
                 .*
             );
         end
@@ -164,6 +166,7 @@ module nbdcache #(
         .critical_word_valid_o  ( critical_word_valid  ),
         .mshr_addr_i            ( mshr_addr            ),
         .mshr_addr_matches_o    ( mshr_addr_matches    ),
+        .mshr_index_matches_o   ( mshr_index_matches   ),
         .active_serving_o       ( active_serving       ),
         .req_o                  ( req             [0]  ),
         .addr_o                 ( addr            [0]  ),
@@ -370,4 +373,3 @@ module tag_cmp #(
     end
 
 endmodule
-


### PR DESCRIPTION
I discussed with Zaruba the reasons behind #54. 

The bug was triggered by a store followed by a load that triggered the eviction of the corresponding line (without saving its contents to memory).  To solve this, the store FSM checks whether its index matches the load index. If they match, the store is treated as if it has missed on the cache. 

I am unsure of the performance implications, or if the regression tests still pass.