### PR TITLE
cache hierarchy changes and LSU load path optimizations

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ dependencies:
 
 sources:
   - include/ariane_pkg.sv
-  - include/nbdcache_pkg.sv
+  - include/std_cache_pkg.sv
   - target: not(synthesis)
     files:
       - src/util/instruction_tracer_pkg.sv
@@ -51,6 +51,7 @@ sources:
   - src/pcgen_stage.sv
   - src/perf_counters.sv
   - src/ptw.sv
+  - src/std_cache_subsystem.sv
   # - src/ariane_regfile_ff.sv
   - src/ariane_regfile.sv
   - src/re_name.sv

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ max_cycles ?= 10000000
 # Test case to run
 test_case ?= core_test
 # QuestaSim Version
-questa_version ?= -10.5c
+questa_version ?=
 # verilator version
 verilator ?= verilator
 # preset which runs a single test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ max_cycles ?= 10000000
 # Test case to run
 test_case ?= core_test
 # QuestaSim Version
-questa_version ?=
+questa_version ?= -10.5c
 # verilator version
 verilator ?= verilator
 # preset which runs a single test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ verilator ?= verilator
 riscv-test ?= rv64ui-p-add
 # Sources
 # Ariane PKG
-ariane_pkg := include/ariane_pkg.sv include/std_cache_pkg.sv 
+ariane_pkg := include/ariane_pkg.sv include/std_cache_pkg.sv
 # utility modules
 util := $(wildcard src/util/*.svh) src/util/instruction_tracer_pkg.sv src/util/instruction_tracer_if.sv \
 		src/util/generic_fifo.sv src/util/cluster_clock_gating.sv src/util/behav_sram.sv
@@ -41,7 +41,7 @@ dpi := $(wildcard tb/dpi/*)
 src := $(wildcard src/*.sv) $(wildcard tb/common/*.sv) $(wildcard src/axi2per/*.sv) $(wildcard src/axi_slice/*.sv) \
 	  $(wildcard src/axi_node/*.sv) $(wildcard src/axi_mem_if/src/*.sv)
 # look for testbenches
-tbs := tb/alu_tb.sv tb/core_tb.sv tb/dcache_arbiter_tb.sv tb/store_queue_tb.sv tb/scoreboard_tb.sv tb/fifo_tb.sv
+tbs := tb/alu_tb.sv tb/core_tb.sv tb/dcache_arbiter_tb.sv tb/store_queue_tb.sv tb/scoreboard_tb.sv tb/fifo_tb.sv 
 
 # RISCV-tests path
 riscv-test-dir := tmp/riscv-tests/build/isa

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ verilator ?= verilator
 riscv-test ?= rv64ui-p-add
 # Sources
 # Ariane PKG
-ariane_pkg := include/ariane_pkg.sv include/nbdcache_pkg.sv
+ariane_pkg := include/ariane_pkg.sv include/std_cache_pkg.sv 
 # utility modules
 util := $(wildcard src/util/*.svh) src/util/instruction_tracer_pkg.sv src/util/instruction_tracer_if.sv \
 		src/util/generic_fifo.sv src/util/cluster_clock_gating.sv src/util/behav_sram.sv

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ verilator ?= verilator
 riscv-test ?= rv64ui-p-add
 # Sources
 # Ariane PKG
-ariane_pkg := include/ariane_pkg.sv include/std_cache_pkg.sv
+ariane_pkg := include/ariane_pkg.sv include/std_cache_pkg.sv 
 # utility modules
 util := $(wildcard src/util/*.svh) src/util/instruction_tracer_pkg.sv src/util/instruction_tracer_if.sv \
 		src/util/generic_fifo.sv src/util/cluster_clock_gating.sv src/util/behav_sram.sv

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -16,7 +16,6 @@
  *              in one package.
  */
 
-
 package ariane_pkg;
     timeunit      1ns;
     timeprecision 1ps;
@@ -47,6 +46,17 @@ package ariane_pkg;
 
     // 32 registers + 1 bit for re-naming = 6
     localparam REG_ADDR_SIZE = 6;
+
+
+    // ---------------
+    // Cache config
+    // ---------------
+    localparam int unsigned INDEX_WIDTH       = 12;
+    localparam int unsigned TAG_WIDTH         = 44;
+    localparam int unsigned CACHE_LINE_WIDTH  = 128;
+    localparam int unsigned SET_ASSOCIATIVITY = 8;
+
+
 
     // ---------------
     // Fetch Stage
@@ -474,6 +484,30 @@ package ariane_pkg;
         DBG_CSR_M0   = 16'hE???,
         DBG_CSR_M1   = 16'hF???
     } debug_reg_t;
+
+    // ----------------------
+    // cache request ports
+    // ----------------------
+
+    typedef struct packed {
+        logic [INDEX_WIDTH-1:0]    address_index;
+        logic [TAG_WIDTH-1:0]      address_tag;
+        logic [63:0]               data_wdata;
+        logic                      data_req;
+        logic                      data_we;
+        logic [7:0]                data_be;
+        logic [1:0]                data_size;
+        logic                      kill_req;
+        logic                      tag_valid;
+        amo_t                      amo_op;
+    } dcache_req_i_t;
+
+    typedef struct packed {
+        logic                      data_gnt;
+        logic                      data_rvalid;
+        logic [63:0]               data_rdata;
+    } dcache_req_o_t;
+
 
     // ----------------------
     // Arithmetic Functions

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -47,20 +47,11 @@ package ariane_pkg;
     // 32 registers + 1 bit for re-naming = 6
     localparam REG_ADDR_SIZE = 6;
 
-
-    // ---------------
-    // Cache config
-    // ---------------
-    localparam int unsigned INDEX_WIDTH       = 12;
-    localparam int unsigned TAG_WIDTH         = 44;
-    localparam int unsigned CACHE_LINE_WIDTH  = 128;
-    localparam int unsigned SET_ASSOCIATIVITY = 8;
-
-
-
     // ---------------
     // Fetch Stage
     // ---------------
+    localparam int unsigned FETCH_WIDTH       = 32;
+
     // Only use struct when signals have same direction
     // exception
     typedef struct packed {
@@ -136,6 +127,22 @@ package ariane_pkg;
     } fu_t;
 
     localparam EXC_OFF_RST      = 8'h80;
+
+    // ---------------
+    // Cache config
+    // ---------------
+
+    // I$
+    parameter int unsigned  ICACHE_INDEX_WIDTH       = 12; // in bit
+    parameter int unsigned  ICACHE_TAG_WIDTH         = 44; // in bit
+    parameter int unsigned  ICACHE_SET_ASSOC         = 4;
+    parameter int unsigned  ICACHE_LINE_WIDTH        = 128; // in bit    
+
+    // D$
+    localparam int unsigned DCACHE_INDEX_WIDTH       = 12;
+    localparam int unsigned DCACHE_TAG_WIDTH         = 44;
+    localparam int unsigned DCACHE_LINE_WIDTH        = 128;
+    localparam int unsigned DCACHE_SET_ASSOC         = 8;
 
     // ---------------
     // EX Stage
@@ -489,17 +496,49 @@ package ariane_pkg;
     // cache request ports
     // ----------------------
 
+    // I$ address translation requests
     typedef struct packed {
-        logic [INDEX_WIDTH-1:0]    address_index;
-        logic [TAG_WIDTH-1:0]      address_tag;
-        logic [63:0]               data_wdata;
-        logic                      data_req;
-        logic                      data_we;
-        logic [7:0]                data_be;
-        logic [1:0]                data_size;
-        logic                      kill_req;
-        logic                      tag_valid;
-        amo_t                      amo_op;
+        logic                     fetch_valid;     // address translation valid
+        logic [63:0]              fetch_paddr;     // physical address in
+        exception_t               fetch_exception; // exception occurred during fetch
+    } icache_areq_i_t;
+
+    typedef struct packed {
+        logic                     fetch_req;       // address translation request
+        logic [63:0]              fetch_vaddr;     // virtual address out
+    } icache_areq_o_t;
+
+    // I$ data requests
+    typedef struct packed {
+        logic                     req;                    // we request a new word
+        logic                     is_speculative;         // is this request speculative or not
+        logic                     kill_s1;                // kill the current request
+        logic                     kill_s2;                // kill the last request
+        logic [63:0]              vaddr;                  // 1st cycle: 12 bit index is taken for lookup
+    } icache_dreq_i_t;        
+        
+    typedef struct packed {        
+        logic                     ready;                  // icache is ready
+        logic                     valid;                  // signals a valid read
+        logic                     is_speculative;         // the fetch was speculative
+        logic [FETCH_WIDTH-1:0]   data;                   // 2+ cycle out: tag
+        logic [63:0]              vaddr;                  // virtual address out
+        exception_t               ex;                     // we've encountered an exception
+    } icache_dreq_o_t;
+
+
+    // D$ data requests
+    typedef struct packed {
+        logic [DCACHE_INDEX_WIDTH-1:0] address_index;
+        logic [DCACHE_TAG_WIDTH-1:0]   address_tag;
+        logic [63:0]                   data_wdata;
+        logic                          data_req;
+        logic                          data_we;
+        logic [7:0]                    data_be;
+        logic [1:0]                    data_size;
+        logic                          kill_req;
+        logic                          tag_valid;
+        amo_t                          amo_op;
     } dcache_req_i_t;
 
     typedef struct packed {

--- a/include/std_cache_pkg.sv
+++ b/include/std_cache_pkg.sv
@@ -19,14 +19,13 @@
 
 package std_cache_pkg;
 
+    // get global params and cache config 
     import ariane_pkg::*;
 
-    localparam int unsigned NR_MSHR           = 1;
-
     // Calculated parameter
-    localparam BYTE_OFFSET = $clog2(CACHE_LINE_WIDTH/8);
-    localparam NUM_WORDS = 2**(INDEX_WIDTH-BYTE_OFFSET);
-    localparam DIRTY_WIDTH = SET_ASSOCIATIVITY*2;
+    localparam DCACHE_BYTE_OFFSET = $clog2(DCACHE_LINE_WIDTH/8);
+    localparam DCACHE_NUM_WORDS   = 2**(DCACHE_INDEX_WIDTH-DCACHE_BYTE_OFFSET);
+    localparam DCACHE_DIRTY_WIDTH = DCACHE_SET_ASSOC*2;
     // localparam DECISION_BIT = 30; // bit on which to decide whether the request is cache-able or not
 
     typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } req_t;
@@ -52,32 +51,32 @@ package std_cache_pkg;
     } miss_req_t;
 
     typedef struct packed {
-        logic [TAG_WIDTH-1:0]           tag;    // tag array
-        logic [CACHE_LINE_WIDTH-1:0]    data;   // data array
+        logic [DCACHE_TAG_WIDTH-1:0]      tag;    // tag array
+        logic [DCACHE_LINE_WIDTH-1:0]    data;   // data array
         logic                           valid;  // state array
         logic                           dirty;  // state array
     } cache_line_t;
 
     // cache line byte enable
     typedef struct packed {
-        logic [TAG_WIDTH-1:0]        tag;   // byte enable into tag array
-        logic [CACHE_LINE_WIDTH-1:0] data;  // byte enable into data array
-        logic [DIRTY_WIDTH/2-1:0]    dirty; // byte enable into state array
-        logic [DIRTY_WIDTH/2-1:0]    valid; // byte enable into state array
+        logic [DCACHE_TAG_WIDTH-1:0]       tag;   // byte enable into tag array
+        logic [DCACHE_LINE_WIDTH-1:0]     data;  // byte enable into data array
+        logic [DCACHE_DIRTY_WIDTH/2-1:0] dirty; // byte enable into state array
+        logic [DCACHE_DIRTY_WIDTH/2-1:0] valid; // byte enable into state array
     } cl_be_t;
 
     // convert one hot to bin for -> needed for cache replacement
-    function automatic logic [$clog2(SET_ASSOCIATIVITY)-1:0] one_hot_to_bin (input logic [SET_ASSOCIATIVITY-1:0] in);
-        for (int unsigned i = 0; i < SET_ASSOCIATIVITY; i++) begin
+    function automatic logic [$clog2(DCACHE_SET_ASSOC)-1:0] one_hot_to_bin (input logic [DCACHE_SET_ASSOC-1:0] in);
+        for (int unsigned i = 0; i < DCACHE_SET_ASSOC; i++) begin
             if (in[i])
                 return i;
         end
     endfunction
     // get the first bit set, returns one hot value
-    function automatic logic [SET_ASSOCIATIVITY-1:0] get_victim_cl (input logic [SET_ASSOCIATIVITY-1:0] valid_dirty);
+    function automatic logic [DCACHE_SET_ASSOC-1:0] get_victim_cl (input logic [DCACHE_SET_ASSOC-1:0] valid_dirty);
         // one-hot return vector
-        logic [SET_ASSOCIATIVITY-1:0] oh = '0;
-        for (int unsigned i = 0; i < SET_ASSOCIATIVITY; i++) begin
+        logic [DCACHE_SET_ASSOC-1:0] oh = '0;
+        for (int unsigned i = 0; i < DCACHE_SET_ASSOC; i++) begin
             if (valid_dirty[i]) begin
                 oh[i] = 1'b1;
                 return oh;

--- a/include/std_cache_pkg.sv
+++ b/include/std_cache_pkg.sv
@@ -1,27 +1,26 @@
-/* Copyright 2018 ETH Zurich and University of Bologna.
- * Copyright and related rights are licensed under the Solderpad Hardware
- * License, Version 0.51 (the “License”); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
- * or agreed to in writing, software, hardware and materials distributed under
- * this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- *
- * File:   nbdcache_pkh.sv
- * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
- * Date:   13.10.2017
- *
- * Description: Contains all the necessary defines for the non-block DCache
- *              of Ariane in one package.
- */
+// Copyright (c) 2018 ETH Zurich, University of Bologna
+// All rights reserved.
+//
+// This code is under development and not yet released to the public.
+// Until it is released, the code is under the copyright of ETH Zurich and
+// the University of Bologna, and may contain confidential and/or unpublished
+// work. Any reuse/redistribution is strictly forbidden without written
+// permission from ETH Zurich.
+//
+// Bug fixes and contributions will eventually be released under the
+// SolderPad open hardware license in the context of the PULP platform
+// (http://www.pulp-platform.org), under the copyright of ETH Zurich and the
+// University of Bologna.
+//
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
+// Description: package for the standard Ariane cache subsystem.
 
-package nbdcache_pkg;
+package std_cache_pkg;
 
-    localparam int unsigned INDEX_WIDTH       = 12;
-    localparam int unsigned TAG_WIDTH         = 44;
-    localparam int unsigned CACHE_LINE_WIDTH  = 128;
-    localparam int unsigned SET_ASSOCIATIVITY = 8;
+    import ariane_pkg::*;
+
     localparam int unsigned NR_MSHR           = 1;
 
     // Calculated parameter
@@ -31,6 +30,7 @@ package nbdcache_pkg;
     // localparam DECISION_BIT = 30; // bit on which to decide whether the request is cache-able or not
 
     typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } req_t;
+
 
     typedef struct packed {
         logic [1:0]      id;     // id for which we handle the miss
@@ -84,4 +84,5 @@ package nbdcache_pkg;
             end
         end
     endfunction
-endpackage
+endpackage : std_cache_pkg
+

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -37,11 +37,7 @@ module ariane #(
         input  logic [63:0]                    boot_addr_i,            // reset boot address
         input  logic [ 3:0]                    core_id_i,              // core id in a multicore environment (reflected in a CSR)
         input  logic [ 5:0]                    cluster_id_i,           // PULP specific if core is used in a clustered environment
-        // Instruction memory interface
-        AXI_BUS.Master                         instr_if,
-        // Data memory interface
-        AXI_BUS.Master                         data_if,                // data cache refill port
-        AXI_BUS.Master                         bypass_if,              // bypass axi port (disabled cache or uncacheable access)
+
         // Interrupt inputs
         input  logic [1:0]                     irq_i,                  // level sensitive IR lines, mip & sip
         input  logic                           ipi_i,                  // inter-processor interrupts
@@ -59,7 +55,12 @@ module ariane #(
         output logic [63:0]                    debug_rdata_o,
         output logic                           debug_halted_o,
         input  logic                           debug_halt_i,
-        input  logic                           debug_resume_i
+        input  logic                           debug_resume_i,
+
+        // memory side
+        AXI_BUS.Master                         instr_if,                // I$ refill port
+        AXI_BUS.Master                         data_if,                 // D$ refill port
+        AXI_BUS.Master                         bypass_if                // bypass axi port (disabled D$ or uncacheable access)
     );
 
     // ------------------------------------------
@@ -209,7 +210,8 @@ module ariane #(
 
     logic                     itlb_miss_ex_perf;
     logic                     dtlb_miss_ex_perf;
-    logic                     dcache_miss_ex_perf;
+    logic                     dcache_miss_cache_perf;
+    logic                     icache_miss_cache_perf;
     // --------------
     // CTRL <-> *
     // --------------
@@ -249,15 +251,19 @@ module ariane #(
     // ----------------
     // ICache <-> *
     // ----------------
-    logic                    flush_icache_ctrl_icache;
+    logic                    icache_flush_ctrl_cache;
     logic                    bypass_icache_csr_icache;
 
+
+    icache_areq_i_t          icache_areq_ex_cache;
+    icache_areq_o_t          icache_areq_cache_ex;
+    icache_dreq_i_t          icache_dreq_if_cache;
+    icache_dreq_o_t          icache_dreq_cache_if;
     // ----------------
     // DCache <-> *
     // ----------------
-    dcache_req_i_t [2:0]     dcache_req_ports_in;
-    dcache_req_o_t [2:0]     dcache_req_ports_out; 
-
+    dcache_req_i_t [2:0]     dcache_req_ports_ex_cache;
+    dcache_req_o_t [2:0]     dcache_req_ports_cache_ex; 
 
 
     assign sec_lvl_o = priv_lvl;
@@ -272,14 +278,10 @@ module ariane #(
     ) i_frontend (
         .flush_i             ( flush_ctrl_if                 ), // not entirely correct
         .flush_bp_i          ( 1'b0                          ),
-        .flush_icache_i      ( flush_icache_ctrl_icache      ),
         .boot_addr_i         ( boot_addr_i                   ),
         .fetch_enable_i      ( fetch_enable                  ),
-        .fetch_req_o         ( fetch_req_if_ex               ),
-        .fetch_vaddr_o       ( fetch_vaddr_if_ex             ),
-        .fetch_valid_i       ( fetch_valid_ex_if             ),
-        .fetch_paddr_i       ( fetch_paddr_ex_if             ),
-        .fetch_exception_i   ( fetch_ex_ex_if                ),
+        .icache_dreq_i       ( icache_dreq_cache_if          ),
+        .icache_dreq_o       ( icache_dreq_if_cache          ),
         .resolved_branch_i   ( resolved_branch               ),
         .pc_commit_i         ( pc_commit                     ),
         .set_pc_commit_i     ( set_pc_ctrl_pcgen             ),
@@ -289,8 +291,6 @@ module ariane #(
         .ex_valid_i          ( ex_commit.valid               ),
         .debug_pc_i          ( pc_debug_pcgen                ),
         .debug_set_pc_i      ( set_pc_debug                  ),
-        .axi                 ( instr_if                      ),
-        .l1_icache_miss_o    (                               ), // performance counters
         .fetch_entry_o       ( fetch_entry_if_id             ),
         .fetch_entry_valid_o ( fetch_valid_if_id             ),
         .fetch_ack_i         ( decode_ack_id_if              ),
@@ -438,18 +438,14 @@ module ariane #(
         .enable_translation_i   ( enable_translation_csr_ex              ), // from CSR
         .en_ld_st_translation_i ( en_ld_st_translation_csr_ex            ),
         .flush_tlb_i            ( flush_tlb_ctrl_ex                      ),
-
-        .fetch_req_i            ( fetch_req_if_ex                        ),
-        .fetch_valid_o          ( fetch_valid_ex_if                      ),
-        .fetch_vaddr_i          ( fetch_vaddr_if_ex                      ),
-        .fetch_paddr_o          ( fetch_paddr_ex_if                      ),
-        .fetch_exception_o      ( fetch_ex_ex_if                         ), // fetch exception to IF
         .priv_lvl_i             ( priv_lvl                               ), // from CSR
         .ld_st_priv_lvl_i       ( ld_st_priv_lvl_csr_ex                  ), // from CSR
         .sum_i                  ( sum_csr_ex                             ), // from CSR
         .mxr_i                  ( mxr_csr_ex                             ), // from CSR
         .satp_ppn_i             ( satp_ppn_csr_ex                        ), // from CSR
         .asid_i                 ( asid_csr_ex                            ), // from CSR
+        .icache_areq_i          ( icache_areq_cache_ex                   ),
+        .icache_areq_o          ( icache_areq_ex_cache                   ),
 
         .mult_ready_o           ( mult_ready_ex_id                       ),
         .mult_valid_i           ( mult_valid_id_ex                       ),
@@ -458,8 +454,8 @@ module ariane #(
         .mult_valid_o           ( mult_valid_ex_id                       ),
 
         // DCACHE interfaces
-        .dcache_req_ports_i     ( dcache_req_ports_out                   ),
-        .dcache_req_ports_o     ( dcache_req_ports_in                    ),
+        .dcache_req_ports_i     ( dcache_req_ports_cache_ex              ),
+        .dcache_req_ports_o     ( dcache_req_ports_ex_cache              ),
 
         .*
     );
@@ -547,8 +543,8 @@ module ariane #(
         .commit_instr_i    ( commit_instr_id_commit ),
         .commit_ack_i      ( commit_ack             ),
 
-        .l1_icache_miss_i  ( 1'b0                   ),
-        .l1_dcache_miss_i  ( dcache_miss_ex_perf    ),
+        .l1_icache_miss_i  ( icache_miss_cache_perf ),
+        .l1_dcache_miss_i  ( dcache_miss_cache_perf ),
         .itlb_miss_i       ( itlb_miss_ex_perf      ),
         .dtlb_miss_i       ( dtlb_miss_ex_perf      ),
 
@@ -585,7 +581,7 @@ module ariane #(
         .fence_i                ( fence_commit_controller       ),
         .sfence_vma_i           ( sfence_vma_commit_controller  ),
 
-        .flush_icache_o         ( flush_icache_ctrl_icache      ),
+        .flush_icache_o         ( icache_flush_ctrl_cache       ),
         .*
     );
 
@@ -595,28 +591,36 @@ module ariane #(
     // -------------------
     
     std_cache_subsystem #(
-        .CACHE_START_ADDR ( CACHE_START_ADDR ),
-        .AXI_ID_WIDTH     ( AXI_ID_WIDTH     ),
-        .AXI_USER_WIDTH   ( AXI_USER_WIDTH   )
-    ) i_std_cache_subsystem (
-        // to D$
-        .clk_i                ( clk_i                                 ),
-        .rst_ni               ( rst_ni                                ),
-        .dcache_data_if       ( data_if                               ),
-        .dcache_bypass_if     ( bypass_if                             ),
-        .dcache_enable_i      ( dcache_en_csr_nbdcache                ),
-        .dcache_flush_i       ( flush_dcache_ctrl_ex | flush_dcache_i ),
-        .dcache_flush_ack_o   ( flush_dcache_ack_ex_ctrl              ),
-        // from PTW, Load Unit and Store Unit             
-        .dcache_amo_commit_i  ( 1'b0                                  ),
-        .dcache_amo_valid_o   (                                       ),
-        .dcache_amo_result_o  (                                       ),
-        .dcache_amo_flush_i   ( 1'b0                                  ),
-        .dcache_miss_o        ( dcache_miss_ex_perf                   ),
-             
-        .dcache_req_ports_i   ( dcache_req_ports_in                   ),
-        .dcache_req_ports_o   ( dcache_req_ports_out                  )
-  );
+        .CACHE_START_ADDR      ( CACHE_START_ADDR                      )
+    ) i_std_cache_subsystem ( 
+        // to D$ 
+        .clk_i                 ( clk_i                                 ),
+        .rst_ni                ( rst_ni                                ),
+        // I$     
+        .icache_flush_i        ( icache_flush_ctrl_cache               ),
+        .icache_fetch_enable_i ( fetch_enable                          ),
+        .icache_miss_o         ( icache_miss_cache_perf                ), 
+        .icache_areq_i         ( icache_areq_ex_cache                  ),
+        .icache_areq_o         ( icache_areq_cache_ex                  ),
+        .icache_dreq_i         ( icache_dreq_if_cache                  ),
+        .icache_dreq_o         ( icache_dreq_cache_if                  ),
+        // D$ 
+        .dcache_enable_i       ( dcache_en_csr_nbdcache                ),
+        .dcache_flush_i        ( flush_dcache_ctrl_ex | flush_dcache_i ),
+        .dcache_flush_ack_o    ( flush_dcache_ack_ex_ctrl              ),
+        // from PTW, Load Unit  and Store Unit             
+        .dcache_amo_commit_i   ( 1'b0                                  ),
+        .dcache_amo_valid_o    (                                       ),
+        .dcache_amo_result_o   (                                       ),
+        .dcache_amo_flush_i    ( 1'b0                                  ),
+        .dcache_miss_o         ( dcache_miss_cache_perf                ),
+        .dcache_req_ports_i    ( dcache_req_ports_ex_cache             ),
+        .dcache_req_ports_o    ( dcache_req_ports_cache_ex             ),
+        // memory side
+        .icache_data_if        ( instr_if                              ),
+        .dcache_data_if        ( data_if                               ),
+        .dcache_bypass_if      ( bypass_if                             )
+  ); 
 
     // ------------
     // Debug

--- a/src/ariane_wrapped.sv
+++ b/src/ariane_wrapped.sv
@@ -121,10 +121,10 @@ module ariane_wrapped #(
                 flush_dcache_q <= 1'b0;
 
             // a write to tohost or fromhost
-            if (i_ariane.ex_stage_i.lsu_i.i_store_unit.data_req_o
-              & i_ariane.ex_stage_i.lsu_i.i_store_unit.data_gnt_i
-              & i_ariane.ex_stage_i.lsu_i.i_store_unit.data_we_o) begin
-                store_address = {i_ariane.ex_stage_i.lsu_i.i_store_unit.address_tag_o, i_ariane.ex_stage_i.lsu_i.i_store_unit.address_index_o[11:3], 3'b0};
+            if (i_ariane.ex_stage_i.lsu_i.i_store_unit.req_port_o.data_req
+              & i_ariane.ex_stage_i.lsu_i.i_store_unit.req_port_i.data_gnt
+              & i_ariane.ex_stage_i.lsu_i.i_store_unit.req_port_o.data_we) begin
+                store_address = {i_ariane.ex_stage_i.lsu_i.i_store_unit.req_port_o.address_tag, i_ariane.ex_stage_i.lsu_i.i_store_unit.req_port_o.address_index[11:3], 3'b0};
 
                 // this assumes that tohost writes are always 64-bit
                 if (store_address == tohost || store_address == fromhost) begin

--- a/src/cache_ctrl.sv
+++ b/src/cache_ctrl.sv
@@ -238,7 +238,7 @@ module cache_ctrl #(
                     // ----------------------------------------------
                     // Check MSHR - Miss Status Handling Register
                     // ----------------------------------------------
-                    mshr_addr_o = {tag_o, mem_req_q.index};
+                    mshr_addr_o = {req_port_i.address_tag, mem_req_q.index};
                     // 1. We've got a match on MSHR and while are going down the
                     //    store path. This means that the miss controller is
                     //    currently evicting our cache-line. As the store is

--- a/src/cache_ctrl.sv
+++ b/src/cache_ctrl.sv
@@ -173,7 +173,6 @@ module cache_ctrl #(
                 // depending on where we come from
                 // For the store case the tag comes in the same cycle
                 tag_o = (state_q == WAIT_TAG_SAVED || mem_req_q.we) ? mem_req_q.tag :  req_port_i.address_tag;
-
                 // we speculatively request another transfer
                 if (req_port_i.data_req && !flush_i) begin
                     req_o      = '1;
@@ -234,7 +233,7 @@ module cache_ctrl #(
                     // ----------------------------------------------
                     // Check MSHR - Miss Status Handling Register
                     // ----------------------------------------------
-                    mshr_addr_o = {req_port_i.address_tag, mem_req_q.index};
+                    mshr_addr_o = {tag_o, mem_req_q.index};
                     // 1. We've got a match on MSHR and while are going down the
                     //    store path. This means that the miss controller is
                     //    currently evicting our cache-line. As the store is

--- a/src/cache_ctrl.sv
+++ b/src/cache_ctrl.sv
@@ -255,7 +255,7 @@ module cache_ctrl #(
                     //    the cache-line again and potentially loosing any
                     //    content we've written so far. This as a consequence
                     //    means we can't have hit on the CL which mean the
-                    //    data_rvalid_o will be de-asserted.
+                    //    req_port_o.data_rvalid will be de-asserted.
                     if ((mshr_index_matches_i && mem_req_q.we) || mshr_addr_matches_i) begin
                         state_d = WAIT_MSHR;
                         // save tag if we didn't already save it e.g.: we are not in in the Tag saved state
@@ -447,12 +447,15 @@ module cache_ctrl #(
             assert (CACHE_LINE_WIDTH == 128) else $error ("Cacheline width has to be 128 for the moment. But only small changes required in data select logic");
         end
         // if the full MSHR address matches so should also match the partial one
-        partial_full_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> mshr_index_matches_i)
+        partial_full_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> mshr_index_matches_i)   else $fatal ("partial mshr index doesn't match");
         // there should never be a valid answer when the MSHR matches
-        no_valid_on_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> !data_rvalid_o)
+        no_valid_on_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> !req_port_o.data_rvalid) else $fatal ("rvalid_o should not be set on MSHR match");
     `endif
     `endif
 endmodule
+
+  
+
 
 module AMO_alu (
         input logic         clk_i,

--- a/src/cache_ctrl.sv
+++ b/src/cache_ctrl.sv
@@ -442,6 +442,7 @@ module cache_ctrl #(
     end
 
     `ifndef SYNTHESIS
+    `ifndef verilator
         initial begin
             assert (CACHE_LINE_WIDTH == 128) else $error ("Cacheline width has to be 128 for the moment. But only small changes required in data select logic");
         end
@@ -449,6 +450,7 @@ module cache_ctrl #(
         partial_full_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> mshr_index_matches_i)
         // there should never be a valid answer when the MSHR matches
         no_valid_on_mshr_match: assert property(@(posedge  clk_i) disable iff (rst_ni !== 1'b0) mshr_addr_matches_i -> !data_rvalid_o)
+    `endif
     `endif
 endmodule
 

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -16,11 +16,8 @@
 import ariane_pkg::*;
 
 module ex_stage #(
-        parameter int          ASID_WIDTH       = 1,
-        parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000,
-        parameter int unsigned AXI_ID_WIDTH     = 10,
-        parameter int unsigned AXI_USER_WIDTH   = 1
-    )(
+        parameter int          ASID_WIDTH       = 1
+    ) (
     input  logic                                   clk_i,    // Clock
     input  logic                                   rst_ni,   // Asynchronous reset active low
     input  logic                                   flush_i,
@@ -94,17 +91,14 @@ module ex_stage #(
     input  logic [43:0]                            satp_ppn_i,
     input  logic [ASID_WIDTH-1:0]                  asid_i,
 
+    // interface to dcache
+    input  dcache_req_o_t [2:0]                    dcache_req_ports_i,  
+    output dcache_req_i_t [2:0]                    dcache_req_ports_o, 
+
     // Performance counters
     output logic                                   itlb_miss_o,
-    output logic                                   dtlb_miss_o,
-    output logic                                   dcache_miss_o,
-
-    // DCache interface
-    input  logic                                   dcache_en_i,
-    input  logic                                   flush_dcache_i,
-    output logic                                   flush_dcache_ack_o,
-    AXI_BUS.Master                                 data_if,
-    AXI_BUS.Master                                 bypass_if
+    output logic                                   dtlb_miss_o
+    
 );
 
     // -----
@@ -135,14 +129,11 @@ module ex_stage #(
     // ----------------
     // Load-Store Unit
     // ----------------
-    lsu #(
-        .CACHE_START_ADDR ( CACHE_START_ADDR ),
-        .AXI_ID_WIDTH     ( AXI_ID_WIDTH     ),
-        .AXI_USER_WIDTH   ( AXI_USER_WIDTH   )
-    ) lsu_i (
-        .commit_i       ( lsu_commit_i       ),
-        .commit_ready_o ( lsu_commit_ready_o ),
-        .data_if        ( data_if            ),
+    lsu lsu_i (
+        .commit_i           ( lsu_commit_i       ),
+        .commit_ready_o     ( lsu_commit_ready_o ),
+        .dcache_req_ports_i ( dcache_req_ports_i ),
+        .dcache_req_ports_o ( dcache_req_ports_o ),
         .*
     );
 

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -79,18 +79,16 @@ module ex_stage #(
     input  logic                                   enable_translation_i,
     input  logic                                   en_ld_st_translation_i,
     input  logic                                   flush_tlb_i,
-    input  logic                                   fetch_req_i,
-    input  logic [63:0]                            fetch_vaddr_i,
-    output logic                                   fetch_valid_o,
-    output logic [63:0]                            fetch_paddr_o,
-    output exception_t                             fetch_exception_o,
     input  priv_lvl_t                              priv_lvl_i,
     input  priv_lvl_t                              ld_st_priv_lvl_i,
     input  logic                                   sum_i,
     input  logic                                   mxr_i,
     input  logic [43:0]                            satp_ppn_i,
     input  logic [ASID_WIDTH-1:0]                  asid_i,
-
+    // icache translation requests
+    input  icache_areq_o_t                         icache_areq_i,         
+    output icache_areq_i_t                         icache_areq_o,       
+    
     // interface to dcache
     input  dcache_req_o_t [2:0]                    dcache_req_ports_i,  
     output dcache_req_i_t [2:0]                    dcache_req_ports_o, 

--- a/src/fifo.sv
+++ b/src/fifo.sv
@@ -1,59 +1,86 @@
 // Copyright 2018 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
+// compliance with the License. You may obtain a copy of the License at
 // http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
 // or agreed to in writing, software, hardware and materials distributed under
 // this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
-//
-// Author: Florian Zaruba, ETH Zurich
-// Date: 24.4.2017
-// Description: Generic FIFO implementation
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
 module fifo #(
-        parameter type dtype            = logic[63:0],
-        parameter int unsigned DEPTH    = 4
-    )(
-        input  logic clk_i,            // Clock
-        input  logic rst_ni,           // Asynchronous reset active low
-        input  logic flush_i,          // flush the queue
-        // status flags
-        output logic full_o,           // queue is full
-        output logic empty_o,          // queue is empty
-        output logic single_element_o, // there is just a single element in the queue
-        // as long as the queue is not full we can push new data
-        input  dtype data_i,           // data to push into the queue
-        input  logic push_i,           // data is valid and can be pushed to the queue
-        // as long as the queue is not empty we can pop new elements
-        output dtype data_o,           // output data
-        input  logic pop_i             // pop head from queue
-    );
+    parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
+    parameter int unsigned ALM_EMPTY_TH = 1,    // almost empty threshold (when to assert alm_empty_o)
+    parameter int unsigned ALM_FULL_TH  = 1,    // almost full threshold (when to assert alm_full_o)
+    parameter type dtype                = logic [DATA_WIDTH-1:0]
+)(
+    input  logic  clk_i,            // Clock
+    input  logic  rst_ni,           // Asynchronous reset active low
+    input  logic  flush_i,          // flush the queue
+    input  logic  testmode_i,       // test_mode to bypass clock gating
+    // status flags
+    output logic  full_o,           // queue is full
+    output logic  empty_o,          // queue is empty
+    output logic  alm_full_o,       // FIFO fillstate >= the specified threshold
+    output logic  alm_empty_o,      // FIFO fillstate <= the specified threshold
+    // as long as the queue is not full we can push new data
+    input  dtype  data_i,           // data to push into the queue
+    input  logic  push_i,           // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    output dtype  data_o,           // output data
+    input  logic  pop_i             // pop head from queue
+);
+    // local parameter
+    // FIFO depth - handle the case of pass-through, synthesizer will do constant propagation
+    localparam int unsigned FIFO_DEPTH = (DEPTH > 0) ? DEPTH : 1;
+    localparam int unsigned ADDR_DEPTH = (DEPTH > 1) ? $clog2(DEPTH) : 1;
+    // clock gating control
+    logic gate_clock;
     // pointer to the read and write section of the queue
-    logic [$clog2(DEPTH) - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
+    logic [ADDR_DEPTH - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
     // keep a counter to keep track of the current queue status
-    int unsigned status_cnt_n, status_cnt_q; // this integer will be truncated by the synthesis tool
+    logic [ADDR_DEPTH:0] status_cnt_n, status_cnt_q; // this integer will be truncated by the synthesis tool
     // actual memory
-    dtype [DEPTH-1:0] mem_n, mem_q;
+    dtype [FIFO_DEPTH - 1:0] mem_n, mem_q;
 
-    assign full_o            = (status_cnt_q == DEPTH);
-    assign empty_o           = (status_cnt_q == 0);
-    assign single_element_o  = (status_cnt_q == 1);
+    if (DEPTH == 0) begin
+        assign empty_o     = ~push_i;
+        assign full_o      = ~pop_i;
+        assign alm_full_o  = 1'b0; // that signal does not make any sense in a FIFO of depth 0
+        assign alm_empty_o = 1'b0; // that signal does not make any sense in a FIFO of depth 0
+    end else begin
+        assign full_o       = (status_cnt_q == FIFO_DEPTH);
+        assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+        assign alm_full_o   = (status_cnt_q >= ALM_FULL_TH);
+        assign alm_empty_o  = (status_cnt_q <= ALM_EMPTY_TH);
+    end
+    // status flags
+
     // read and write queue logic
     always_comb begin : read_write_comb
         // default assignment
         read_pointer_n  = read_pointer_q;
         write_pointer_n = write_pointer_q;
         status_cnt_n    = status_cnt_q;
-        data_o          = mem_q[read_pointer_q];
+        data_o          = (DEPTH == 0) ? data_i : mem_q[read_pointer_q];
         mem_n           = mem_q;
+        gate_clock      = 1'b1;
+
         // push a new element to the queue
         if (push_i && ~full_o) begin
             // push the data onto the queue
             mem_n[write_pointer_q] = data_i;
-            // increment the write counter, this counter can overflow
-            write_pointer_n = write_pointer_q + 1;
+            // un-gate the clock, we want to write something
+            gate_clock = 1'b0;
+            // increment the write counter
+            if (write_pointer_q == FIFO_DEPTH-1)
+                write_pointer_n = '0;
+            else
+                write_pointer_n = write_pointer_q + 1;
             // increment the overall counter
             status_cnt_n    = status_cnt_q + 1;
         end
@@ -61,14 +88,25 @@ module fifo #(
         if (pop_i && ~empty_o) begin
             // read from the queue is a default assignment
             // but increment the read pointer...
-            read_pointer_n = read_pointer_q + 1;
+            if (read_pointer_n == FIFO_DEPTH-1)
+                read_pointer_n = '0;
+            else
+                read_pointer_n = read_pointer_q + 1;
             // ... and decrement the overall count
-            mem_n[read_pointer_q] = '0;
             status_cnt_n   = status_cnt_q - 1;
         end
+
         // keep the count pointer stable if we push and pop at the same time
-        if (push_i &&  ~full_o && pop_i && ~empty_o)
+        if (push_i && pop_i &&  ~full_o && ~empty_o)
             status_cnt_n   = status_cnt_q;
+
+        // FIFO is in pass through mode -> do not change the pointers
+        if (FALL_THROUGH && (status_cnt_q == 0) && push_i && pop_i) begin
+            data_o = data_i;
+            status_cnt_n = status_cnt_q;
+            read_pointer_n = read_pointer_q;
+            write_pointer_n = write_pointer_q;
+        end
     end
 
     // sequential process
@@ -77,33 +115,39 @@ module fifo #(
             read_pointer_q  <= '0;
             write_pointer_q <= '0;
             status_cnt_q    <= '0;
-            mem_q           <= '0;
-        end else if (flush_i) begin
-            read_pointer_q  <= '0;
-            write_pointer_q <= '0;
-            status_cnt_q    <= '0;
-            mem_q           <= '0;
         end else begin
-            read_pointer_q  <= read_pointer_n;
-            write_pointer_q <= write_pointer_n;
-            status_cnt_q    <= status_cnt_n;
-            mem_q           <= mem_n;
+            if (flush_i) begin
+                read_pointer_q  <= '0;
+                write_pointer_q <= '0;
+                status_cnt_q    <= '0;
+             end else begin
+                read_pointer_q  <= read_pointer_n;
+                write_pointer_q <= write_pointer_n;
+                status_cnt_q    <= status_cnt_n;
+            end
         end
     end
 
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            mem_q <= '0;
+        end else if (!gate_clock) begin
+            mem_q <= mem_n;
+        end
+    end
     `ifndef SYNTHESIS
     `ifndef verilator
     initial begin
-        assert (DEPTH == 2**$clog2(DEPTH)) else $fatal("FIFO size needs to be a power of two.");
+        // assert ((THRESHOLD - 1) > DEPTH) else $error("Threshold can't be bigger than the DEPTH.");
 
-    assert property(
-        @(posedge clk_i) (rst_ni && full_o |-> ~push_i))
-        else $error ("Trying to push new data although the FIFO is full.");
+        assert property(
+            @(posedge clk_i) (rst_ni && full_o |-> ~push_i))
+            else $warning ("Trying to push new data although the FIFO is full.");
 
-    assert property(
-        @(posedge clk_i) (rst_ni && empty_o |-> ~pop_i))
-        else $error ("Trying to pop data although the FIFO is empty.");
+        assert property(
+            @(posedge clk_i) (rst_ni && empty_o |-> ~pop_i))
+            else $warning ("Trying to pop data although the FIFO is empty.");
     end
     `endif
     `endif
-endmodule
+endmodule // generic_fifo

--- a/src/frontend.sv
+++ b/src/frontend.sv
@@ -18,8 +18,6 @@ module frontend #(
     parameter int unsigned BTB_ENTRIES       = 8,
     parameter int unsigned BHT_ENTRIES       = 1024,
     parameter int unsigned RAS_DEPTH         = 4,
-    parameter int unsigned SET_ASSOCIATIVITY = 4,
-    parameter int unsigned CACHE_LINE_WIDTH  = 64, // in bit
     parameter int unsigned FETCH_WIDTH       = 32
 )(
     input  logic               clk_i,              // Clock

--- a/src/frontend.sv
+++ b/src/frontend.sv
@@ -12,28 +12,21 @@
 // Date: 08.02.2018
 // Description: Ariane Instruction Fetch Frontend
 
+
 import ariane_pkg::*;
 
 module frontend #(
     parameter int unsigned BTB_ENTRIES       = 8,
     parameter int unsigned BHT_ENTRIES       = 1024,
-    parameter int unsigned RAS_DEPTH         = 4,
-    parameter int unsigned FETCH_WIDTH       = 32
+    parameter int unsigned RAS_DEPTH         = 4
 )(
     input  logic               clk_i,              // Clock
     input  logic               rst_ni,             // Asynchronous reset active low
     input  logic               flush_i,            // flush request for PCGEN
     input  logic               flush_bp_i,         // flush branch prediction
-    input  logic               flush_icache_i,     // instruction fence in
     // global input
     input  logic [63:0]        boot_addr_i,
     input  logic               fetch_enable_i,     // start fetching instructions
-    // Address translation interface
-    output logic               fetch_req_o,        // address translation request
-    output logic [63:0]        fetch_vaddr_o,      // virtual address out
-    input  logic               fetch_valid_i,      // address translation valid
-    input  logic [63:0]        fetch_paddr_i,      // physical address in
-    input  exception_t         fetch_exception_i,  // exception occurred during fetch
     // Set a new PC
     // mispredict
     input  branchpredict_t     resolved_branch_i,  // from controller signaling a branch_predict -> update BTB
@@ -49,9 +42,9 @@ module frontend #(
     input  logic [63:0]        debug_pc_i,         // PC from debug stage
     input  logic               debug_set_pc_i,     // Set PC request from debug
     // Instruction Fetch
-    AXI_BUS.Master             axi,
-    output logic               l1_icache_miss_o,    // instruction cache missed
-    //
+    input  icache_dreq_o_t     icache_dreq_i,         
+    output icache_dreq_i_t     icache_dreq_o,       
+    
     // instruction output port -> to processor back-end
     output fetch_entry_t       fetch_entry_o,       // fetch entry containing all relevant data for the ID stage
     output logic               fetch_entry_valid_o, // instruction in IF is valid
@@ -61,14 +54,14 @@ module frontend #(
     localparam int unsigned INSTR_PER_FETCH = FETCH_WIDTH/16;
 
     // Registers
-    logic [31:0] icache_data_d,  icache_data_q;
-    logic        icache_valid_d, icache_valid_q;
-    exception_t  icache_ex_d,    icache_ex_q;
+    logic [31:0] icache_data_q;
+    logic        icache_valid_q;
+    exception_t  icache_ex_q;
 
     logic        instruction_valid;
 
-    logic        icache_speculative_d, icache_speculative_q;
-    logic [63:0] icache_vaddr_d, icache_vaddr_q;
+    logic        icache_speculative_q;
+    logic [63:0] icache_vaddr_q;
 
     // BHT, BTB and RAS prediction
     bht_prediction_t bht_prediction;
@@ -79,8 +72,6 @@ module frontend #(
     logic            ras_push, ras_pop;
     logic [63:0]     ras_update;
 
-    // icache control signals
-    logic icache_req, kill_s1, kill_s2, icache_ready;
 
     // instruction fetch is ready
     logic          if_ready;
@@ -101,12 +92,9 @@ module frontend #(
     logic [INSTR_PER_FETCH-1:0][31:0] instr;
     logic [INSTR_PER_FETCH-1:0][63:0] addr;
 
-    // virtual address of current fetch
-    logic [63:0]   fetch_vaddr;
-
     logic [63:0]   bp_vaddr;
     logic          bp_valid; // we have a valid branch-prediction
-    logic          fetch_is_speculative; // is it a speculative fetch or a fetch which need to do for sure
+    
     // branch-prediction which we inject into the pipeline
     branchpredict_sbe_t  bp_sbe;
     logic                fifo_valid, fifo_ready; // fetch FIFO
@@ -166,7 +154,7 @@ module frontend #(
             unaligned_instr_d = icache_data_q[31:16];
         end
 
-        if (kill_s2) begin
+        if (icache_dreq_o.kill_s2) begin
             unaligned_d = 1'b0;
         end
     end
@@ -177,20 +165,20 @@ module frontend #(
         automatic logic take_rvi_cf; // take the control flow change (non-compressed)
         automatic logic take_rvc_cf; // take the control flow change (compressed)
 
-        take_rvi_cf     = 1'b0;
-        take_rvc_cf     = 1'b0;
-        ras_pop         = 1'b0;
-        ras_push        = 1'b0;
-        ras_update      = '0;
-        taken           = '0;
-        take_rvi_cf     = 1'b0;
-        if_ready        = icache_ready & fifo_ready;
-        icache_req      = fifo_ready;
+        take_rvi_cf       = 1'b0;
+        take_rvc_cf       = 1'b0;
+        ras_pop           = 1'b0;
+        ras_push          = 1'b0;
+        ras_update        = '0;
+        taken             = '0;
+        take_rvi_cf       = 1'b0;
+        if_ready          = icache_dreq_i.ready & fifo_ready;
+        icache_dreq_o.req = fifo_ready;
 
-        bp_vaddr        = '0;    // predicted address
-        bp_valid        = 1'b0;  // prediction is valid
+        bp_vaddr          = '0;    // predicted address
+        bp_valid          = 1'b0;  // prediction is valid
 
-        bp_sbe.cf_type = RAS;
+        bp_sbe.cf_type    = RAS;
 
         // only predict if the response is valid
         if (instruction_valid) begin
@@ -271,18 +259,18 @@ module frontend #(
     assign is_mispredict = resolved_branch_i.valid & resolved_branch_i.is_mispredict;
 
     always_comb begin : id_if
-        kill_s1 = 1'b0;
-        kill_s2 = 1'b0;
+        icache_dreq_o.kill_s1 = 1'b0;
+        icache_dreq_o.kill_s2 = 1'b0;
 
         // we mis-predicted so kill the icache request and the fetch queue
         if (is_mispredict || flush_i) begin
-            kill_s1 = 1'b1;
-            kill_s2 = 1'b1;
+            icache_dreq_o.kill_s1 = 1'b1;
+            icache_dreq_o.kill_s2 = 1'b1;
         end
 
         // if we have a valid branch-prediction we need to kill the last cache request
         if (bp_valid) begin
-            kill_s2 = 1'b1;
+            icache_dreq_o.kill_s2 = 1'b1;
         end
 
         fifo_valid = icache_valid_q;
@@ -319,7 +307,7 @@ module frontend #(
     always_comb begin : npc_select
         automatic logic [63:0] fetch_address;
 
-        fetch_is_speculative = 1'b0;
+        icache_dreq_o.is_speculative = 1'b0;
 
         fetch_address    = npc_q;
         // keep stable by default
@@ -328,7 +316,7 @@ module frontend #(
         // 1. Branch Prediction
         // -------------------------------
         if (bp_valid) begin
-            fetch_is_speculative = 1'b1;
+            icache_dreq_o.is_speculative = 1'b1;
             fetch_address = bp_vaddr;
             npc_d = bp_vaddr;
         end
@@ -337,7 +325,7 @@ module frontend #(
         // -------------------------------
         if (if_ready && fetch_enable_i) begin
             npc_d = {fetch_address[63:2], 2'b0}  + 64'h4;
-            fetch_is_speculative = 1'b1;
+            icache_dreq_o.is_speculative = 1'b1;
         end
         // -------------------------------
         // 2. Control flow change request
@@ -376,7 +364,7 @@ module frontend #(
             npc_d = debug_pc_i;
         end
 
-        fetch_vaddr = fetch_address;
+        icache_dreq_o.vaddr = fetch_address;
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -392,11 +380,11 @@ module frontend #(
             unaligned_instr_q    <= '0;
         end else begin
             npc_q                <= npc_d;
-            icache_data_q        <= icache_data_d;
-            icache_valid_q       <= icache_valid_d;
-            icache_speculative_q <= icache_speculative_d;
-            icache_vaddr_q       <= icache_vaddr_d;
-            icache_ex_q          <= icache_ex_d;
+            icache_data_q        <= icache_dreq_i.data;
+            icache_valid_q       <= icache_dreq_i.valid;
+            icache_speculative_q <= icache_dreq_i.is_speculative;
+            icache_vaddr_q       <= icache_dreq_i.vaddr;
+            icache_ex_q          <= icache_dreq_i.ex;
             unaligned_q          <= unaligned_d;
             unaligned_address_q  <= unaligned_address_d;
             unaligned_instr_q    <= unaligned_instr_d;
@@ -433,27 +421,7 @@ module frontend #(
         .*
     );
 
-    icache #(
-        .SET_ASSOCIATIVITY ( 4                    ),
-        .CACHE_LINE_WIDTH  ( 128                  ),
-        .FETCH_WIDTH       ( FETCH_WIDTH          )
-    ) i_icache (
-        .flush_i          ( flush_icache_i        ),
-        .vaddr_i          ( fetch_vaddr           ), // 1st cycle
-        .is_speculative_i ( fetch_is_speculative  ), // 1st cycle
-        .data_o           ( icache_data_d         ),
-        .req_i            ( icache_req            ),
-        .kill_s1_i        ( kill_s1               ),
-        .kill_s2_i        ( kill_s2               ),
-        .ready_o          ( icache_ready          ),
-        .valid_o          ( icache_valid_d        ),
-        .ex_o             ( icache_ex_d           ),
-        .is_speculative_o ( icache_speculative_d  ),
-        .vaddr_o          ( icache_vaddr_d        ),
-        .axi              ( axi                   ),
-        .miss_o           ( l1_icache_miss_o      ),
-        .*
-    );
+
 
     for (genvar i = 0; i < INSTR_PER_FETCH; i++) begin
         instr_scan i_instr_scan (

--- a/src/if_stage.sv
+++ b/src/if_stage.sv
@@ -202,20 +202,6 @@ module if_stage (
     // ---------------------------------
     // Address and Branch-predict Queue
     // ---------------------------------
-/*    oldfifo #(
-        .dtype            ( address_fifo_t          ),
-        .DEPTH            ( 2                       )  // right now we support two outstanding transactions
-    ) i_fifo (
-        .flush_i          ( 1'b0                    ), // do not flush, we need to keep track of all outstanding rvalids
-        .full_o           ( full                    ), // the address buffer is full
-        .empty_o          ( empty                   ), // ...or empty
-        .single_element_o ( single_element          ), // just a single element in the queue
-        .data_i           ( push_data               ),
-        .push_i           ( instr_gnt_i             ), // if we got a grant push the address and data
-        .data_o           ( pop_data                ), // data we send to the fetch_fifo, along with the instr data which comes from memory
-        .pop_i            ( fifo_valid || pop_empty ), // pop the data if we say that the fetch is valid
-        .*
-    );*/
 
     fifo #(
         .dtype            ( address_fifo_t          ),

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -356,7 +356,7 @@ module load_unit (
 
     // select correct sign bit in parallel to result shifter above
     // pull to 0 if unsigned
-    assign sign_bit       = signed_q & sign_bits [ idx_q ] | fp_sign_q;
+    assign sign_bit       = signed_q & sign_bits[idx_q] | fp_sign_q;
 
     // result mux
     always_comb begin

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -37,19 +37,8 @@ module load_unit (
     output logic [11:0]              page_offset_o,
     input  logic                     page_offset_matches_i,
     // D$ interface
-    output logic [11:0]              address_index_o,
-    output logic [43:0]              address_tag_o,
-    output amo_t                     amo_op_o,
-    output logic [63:0]              data_wdata_o,
-    output logic                     data_req_o,
-    output logic                     data_we_o,
-    output logic [7:0]               data_be_o,
-    output logic [1:0]               data_size_o,
-    output logic                     kill_req_o,
-    output logic                     tag_valid_o,
-    input  logic                     data_gnt_i,
-    input  logic                     data_rvalid_i,
-    input  logic [63:0]              data_rdata_i
+    input dcache_req_o_t             req_port_i,
+    output dcache_req_i_t            req_port_o  
 );
     enum logic [2:0] {IDLE, WAIT_GNT, SEND_TAG, WAIT_PAGE_OFFSET, ABORT_TRANSACTION, WAIT_TRANSLATION, WAIT_FLUSH} NS, CS;
     // in order to decouple the response interface from the request interface we need a
@@ -65,14 +54,14 @@ module load_unit (
     // feed-through the virtual address for VA translation
     assign vaddr_o = lsu_ctrl_i.vaddr;
     // this is a read-only interface so set the write enable to 0
-    assign data_we_o = 1'b0;
+    assign req_port_o.data_we = 1'b0;
     // compose the queue data, control is handled in the FSM
     assign in_data = {lsu_ctrl_i.trans_id, lsu_ctrl_i.vaddr[2:0], lsu_ctrl_i.operator};
     // output address
     // we can now output the lower 12 bit as the index to the cache
-    assign address_index_o = lsu_ctrl_i.vaddr[11:0];
+    assign req_port_o.address_index = lsu_ctrl_i.vaddr[11:0];
     // translation from last cycle, again: control is handled in the FSM
-    assign address_tag_o   = paddr_i[55:12];
+    assign req_port_o.address_tag   = paddr_i[55:12];
     // directly output an exception
     assign ex_o = ex_i;
 
@@ -81,16 +70,16 @@ module load_unit (
     // ---------------
     always_comb begin : load_control
         // default assignments
-        NS                = CS;
-        load_data_n       = load_data_q;
-        translation_req_o = 1'b0;
-        data_req_o        = 1'b0;
+        NS                   = CS;
+        load_data_n          = load_data_q;
+        translation_req_o    = 1'b0;
+        req_port_o.data_req  = 1'b0;
         // tag control
-        kill_req_o        = 1'b0;
-        tag_valid_o       = 1'b0;
-        data_be_o         = lsu_ctrl_i.be;
-        data_size_o       = extract_transfer_size(lsu_ctrl_i.operator);
-        pop_ld_o          = 1'b0;
+        req_port_o.kill_req  = 1'b0;
+        req_port_o.tag_valid = 1'b0;
+        req_port_o.data_be   = lsu_ctrl_i.be;
+        req_port_o.data_size = extract_transfer_size(lsu_ctrl_i.operator);
+        pop_ld_o             = 1'b0;
 
         case (CS)
             IDLE: begin
@@ -102,9 +91,9 @@ module load_unit (
                     // check if the page offset matches with a store, if it does then stall and wait
                     if (!page_offset_matches_i) begin
                         // make a load request to memory
-                        data_req_o = 1'b1;
+                        req_port_o.data_req = 1'b1;
                         // we got no data grant so wait for the grant before sending the tag
-                        if (!data_gnt_i) begin
+                        if (!req_port_i.data_gnt) begin
                             NS = WAIT_GNT;
                         end else begin
                             if (dtlb_hit_i) begin
@@ -133,8 +122,8 @@ module load_unit (
             // we are here because of a TLB miss, we need to abort the current request and give way for the
             // PTW walker to satisfy the TLB miss
             ABORT_TRANSACTION: begin
-                kill_req_o  = 1'b1;
-                tag_valid_o = 1'b1;
+                req_port_o.kill_req  = 1'b1;
+                req_port_o.tag_valid = 1'b1;
                 // redo the request by going back to the wait gnt state
                 NS          = WAIT_TRANSLATION;
             end
@@ -150,9 +139,9 @@ module load_unit (
                 // keep the translation request up
                 translation_req_o = 1'b1;
                 // keep the request up
-                data_req_o = 1'b1;
+                req_port_o.data_req = 1'b1;
                 // we finally got a data grant
-                if (data_gnt_i) begin
+                if (req_port_i.data_gnt) begin
                     // so we send the tag in the next cycle
                     if (dtlb_hit_i) begin
                         NS = SEND_TAG;
@@ -164,7 +153,7 @@ module load_unit (
             end
             // we know for sure that the tag we want to send is valid
             SEND_TAG: begin
-                tag_valid_o = 1'b1;
+                req_port_o.tag_valid = 1'b1;
                 NS = IDLE;
                 // we can make a new request here if we got one
                 if (valid_i) begin
@@ -174,9 +163,9 @@ module load_unit (
                     // check if the page offset matches with a store, if it does stall and wait
                     if (!page_offset_matches_i) begin
                         // make a load request to memory
-                        data_req_o = 1'b1;
+                        req_port_o.data_req = 1'b1;
                         // we got no data grant so wait for the grant before sending the tag
-                        if (!data_gnt_i) begin
+                        if (!req_port_i.data_gnt) begin
                             NS = WAIT_GNT;
                         end else begin
                             // we got a grant so we can send the tag in the next cycle
@@ -197,15 +186,15 @@ module load_unit (
                 // ----------
                 // if we got an exception we need to kill the request immediately
                 if (ex_i.valid) begin
-                    kill_req_o = 1'b1;
+                    req_port_o.kill_req = 1'b1;
                 end
             end
 
             WAIT_FLUSH: begin
                 // the D$ arbiter will take care of presenting this to the memory only in case we
                 // have an outstanding request
-                kill_req_o  = 1'b1;
-                tag_valid_o = 1'b1;
+                req_port_o.kill_req  = 1'b1;
+                req_port_o.tag_valid = 1'b1;
                 // we've killed the current request so we can go back to idle
                 NS = IDLE;
             end
@@ -217,7 +206,7 @@ module load_unit (
             // the next state will be the idle state
             NS = IDLE;
             // pop load - but only if we are not getting an rvalid in here - otherwise we will over-wright an incoming transaction
-            if (!data_rvalid_i)
+            if (!req_port_i.data_rvalid)
                 pop_ld_o = 1'b1;
         end
 
@@ -241,9 +230,9 @@ module load_unit (
         // output the queue data directly, the valid signal is set corresponding to the process above
         trans_id_o = load_data_q.trans_id;
         // we got an rvalid and are currently not flushing and not aborting the request
-        if (data_rvalid_i && CS != WAIT_FLUSH) begin
+        if (req_port_i.data_rvalid && CS != WAIT_FLUSH) begin
             // we killed the request
-            if(!kill_req_o)
+            if(!req_port_o.kill_req)
                 valid_o = 1'b1;
             // the output is also valid if we got an exception
             if (ex_i.valid)
@@ -254,7 +243,7 @@ module load_unit (
         // exceptions can retire out-of-order -> but we need to give priority to non-excepting load and stores
         // so we simply check if we got an rvalid if so we prioritize it by not retiring the exception - we simply go for another
         // round in the load FSM
-        if (valid_i && ex_i.valid && !data_rvalid_i) begin
+        if (valid_i && ex_i.valid && !req_port_i.data_rvalid) begin
             valid_o    = 1'b1;
             trans_id_o = lsu_ctrl_i.trans_id;
         // if we are waiting for the translation to finish do not give a valid signal yet
@@ -280,33 +269,33 @@ module load_unit (
     // AMO Operation
     // ---------------
     always_comb begin : amo_op_select
-        amo_op_o = AMO_NONE;
+        req_port_o.amo_op = AMO_NONE;
 
         if (lsu_ctrl_i.valid) begin
             case (lsu_ctrl_i.operator)
-                AMO_LRW:    amo_op_o = AMO_LR;
-                AMO_LRD:    amo_op_o = AMO_LR;
-                AMO_SCW:    amo_op_o = AMO_SC;
-                AMO_SCD:    amo_op_o = AMO_SC;
-                AMO_SWAPW:  amo_op_o = AMO_SWAP;
-                AMO_ADDW:   amo_op_o = AMO_ADD;
-                AMO_ANDW:   amo_op_o = AMO_AND;
-                AMO_ORW:    amo_op_o = AMO_OR;
-                AMO_XORW:   amo_op_o = AMO_XOR;
-                AMO_MAXW:   amo_op_o = AMO_MAX;
-                AMO_MAXWU:  amo_op_o = AMO_MAXU;
-                AMO_MINW:   amo_op_o = AMO_MIN;
-                AMO_MINWU:  amo_op_o = AMO_MINU;
-                AMO_SWAPD:  amo_op_o = AMO_SWAP;
-                AMO_ADDD:   amo_op_o = AMO_ADD;
-                AMO_ANDD:   amo_op_o = AMO_AND;
-                AMO_ORD:    amo_op_o = AMO_OR;
-                AMO_XORD:   amo_op_o = AMO_XOR;
-                AMO_MAXD:   amo_op_o = AMO_MAX;
-                AMO_MAXDU:  amo_op_o = AMO_MAXU;
-                AMO_MIND:   amo_op_o = AMO_MIN;
-                AMO_MINDU:  amo_op_o = AMO_MINU;
-                default: amo_op_o = AMO_NONE;
+                AMO_LRW:    req_port_o.amo_op = AMO_LR;
+                AMO_LRD:    req_port_o.amo_op = AMO_LR;
+                AMO_SCW:    req_port_o.amo_op = AMO_SC;
+                AMO_SCD:    req_port_o.amo_op = AMO_SC;
+                AMO_SWAPW:  req_port_o.amo_op = AMO_SWAP;
+                AMO_ADDW:   req_port_o.amo_op = AMO_ADD;
+                AMO_ANDW:   req_port_o.amo_op = AMO_AND;
+                AMO_ORW:    req_port_o.amo_op = AMO_OR;
+                AMO_XORW:   req_port_o.amo_op = AMO_XOR;
+                AMO_MAXW:   req_port_o.amo_op = AMO_MAX;
+                AMO_MAXWU:  req_port_o.amo_op = AMO_MAXU;
+                AMO_MINW:   req_port_o.amo_op = AMO_MIN;
+                AMO_MINWU:  req_port_o.amo_op = AMO_MINU;
+                AMO_SWAPD:  req_port_o.amo_op = AMO_SWAP;
+                AMO_ADDD:   req_port_o.amo_op = AMO_ADD;
+                AMO_ANDD:   req_port_o.amo_op = AMO_AND;
+                AMO_ORD:    req_port_o.amo_op = AMO_OR;
+                AMO_XORD:   req_port_o.amo_op = AMO_XOR;
+                AMO_MAXD:   req_port_o.amo_op = AMO_MAX;
+                AMO_MAXDU:  req_port_o.amo_op = AMO_MAXU;
+                AMO_MIND:   req_port_o.amo_op = AMO_MIN;
+                AMO_MINDU:  req_port_o.amo_op = AMO_MINU;
+                default: req_port_o.amo_op = AMO_NONE;
             endcase
         end
     end
@@ -321,44 +310,44 @@ module load_unit (
 
     // double words
     always_comb begin : sign_extend_double_word
-        rdata_d_ext = data_rdata_i[63:0];
+        rdata_d_ext = req_port_i.data_rdata[63:0];
     end
 
     // sign extension for words
     always_comb begin : sign_extend_word
         case (load_data_q.address_offset)
-            default: rdata_w_ext = (load_data_q.operator == LW) ? {{32{data_rdata_i[31]}}, data_rdata_i[31:0]}  : {32'h0, data_rdata_i[31:0]};
-            3'b001:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{data_rdata_i[39]}}, data_rdata_i[39:8]}  : {32'h0, data_rdata_i[39:8]};
-            3'b010:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{data_rdata_i[47]}}, data_rdata_i[47:16]} : {32'h0, data_rdata_i[47:16]};
-            3'b011:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{data_rdata_i[55]}}, data_rdata_i[55:24]} : {32'h0, data_rdata_i[55:24]};
-            3'b100:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{data_rdata_i[63]}}, data_rdata_i[63:32]} : {32'h0, data_rdata_i[63:32]};
+            default: rdata_w_ext = (load_data_q.operator == LW) ? {{32{req_port_i.data_rdata[31]}}, req_port_i.data_rdata[31:0]}  : {32'h0, req_port_i.data_rdata[31:0]};
+            3'b001:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{req_port_i.data_rdata[39]}}, req_port_i.data_rdata[39:8]}  : {32'h0, req_port_i.data_rdata[39:8]};
+            3'b010:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{req_port_i.data_rdata[47]}}, req_port_i.data_rdata[47:16]} : {32'h0, req_port_i.data_rdata[47:16]};
+            3'b011:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{req_port_i.data_rdata[55]}}, req_port_i.data_rdata[55:24]} : {32'h0, req_port_i.data_rdata[55:24]};
+            3'b100:  rdata_w_ext = (load_data_q.operator == LW) ? {{32{req_port_i.data_rdata[63]}}, req_port_i.data_rdata[63:32]} : {32'h0, req_port_i.data_rdata[63:32]};
         endcase
     end
 
     // sign extension for half words
     always_comb begin : sign_extend_half_word
         case (load_data_q.address_offset)
-            default: rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[15]}}, data_rdata_i[15:0]}  : {48'h0, data_rdata_i[15:0]};
-            3'b001:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[23]}}, data_rdata_i[23:8]}  : {48'h0, data_rdata_i[23:8]};
-            3'b010:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[31]}}, data_rdata_i[31:16]} : {48'h0, data_rdata_i[31:16]};
-            3'b011:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[39]}}, data_rdata_i[39:24]} : {48'h0, data_rdata_i[39:24]};
-            3'b100:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[47]}}, data_rdata_i[47:32]} : {48'h0, data_rdata_i[47:32]};
-            3'b101:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[55]}}, data_rdata_i[55:40]} : {48'h0, data_rdata_i[55:40]};
-            3'b110:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{data_rdata_i[63]}}, data_rdata_i[63:48]} : {48'h0, data_rdata_i[63:48]};
+            default: rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[15]}}, req_port_i.data_rdata[15:0]}  : {48'h0, req_port_i.data_rdata[15:0]};
+            3'b001:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[23]}}, req_port_i.data_rdata[23:8]}  : {48'h0, req_port_i.data_rdata[23:8]};
+            3'b010:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[31]}}, req_port_i.data_rdata[31:16]} : {48'h0, req_port_i.data_rdata[31:16]};
+            3'b011:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[39]}}, req_port_i.data_rdata[39:24]} : {48'h0, req_port_i.data_rdata[39:24]};
+            3'b100:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[47]}}, req_port_i.data_rdata[47:32]} : {48'h0, req_port_i.data_rdata[47:32]};
+            3'b101:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[55]}}, req_port_i.data_rdata[55:40]} : {48'h0, req_port_i.data_rdata[55:40]};
+            3'b110:  rdata_h_ext = (load_data_q.operator == LH) ? {{48{req_port_i.data_rdata[63]}}, req_port_i.data_rdata[63:48]} : {48'h0, req_port_i.data_rdata[63:48]};
         endcase
     end
 
     // sign extend byte
     always_comb begin : sign_extend_byte
         case (load_data_q.address_offset)
-            default: rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[7]}},  data_rdata_i[7:0]}   : {56'h0, data_rdata_i[7:0]};
-            3'b001:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[15]}}, data_rdata_i[15:8]}  : {56'h0, data_rdata_i[15:8]};
-            3'b010:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[23]}}, data_rdata_i[23:16]} : {56'h0, data_rdata_i[23:16]};
-            3'b011:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[31]}}, data_rdata_i[31:24]} : {56'h0, data_rdata_i[31:24]};
-            3'b100:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[39]}}, data_rdata_i[39:32]} : {56'h0, data_rdata_i[39:32]};
-            3'b101:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[47]}}, data_rdata_i[47:40]} : {56'h0, data_rdata_i[47:40]};
-            3'b110:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[55]}}, data_rdata_i[55:48]} : {56'h0, data_rdata_i[55:48]};
-            3'b111:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{data_rdata_i[63]}}, data_rdata_i[63:56]} : {56'h0, data_rdata_i[63:56]};
+            default: rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[7]}},  req_port_i.data_rdata[7:0]}   : {56'h0, req_port_i.data_rdata[7:0]};
+            3'b001:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[15]}}, req_port_i.data_rdata[15:8]}  : {56'h0, req_port_i.data_rdata[15:8]};
+            3'b010:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[23]}}, req_port_i.data_rdata[23:16]} : {56'h0, req_port_i.data_rdata[23:16]};
+            3'b011:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[31]}}, req_port_i.data_rdata[31:24]} : {56'h0, req_port_i.data_rdata[31:24]};
+            3'b100:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[39]}}, req_port_i.data_rdata[39:32]} : {56'h0, req_port_i.data_rdata[39:32]};
+            3'b101:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[47]}}, req_port_i.data_rdata[47:40]} : {56'h0, req_port_i.data_rdata[47:40]};
+            3'b110:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[55]}}, req_port_i.data_rdata[55:48]} : {56'h0, req_port_i.data_rdata[55:48]};
+            3'b111:  rdata_b_ext = (load_data_q.operator == LB) ? {{56{req_port_i.data_rdata[63]}}, req_port_i.data_rdata[63:56]} : {56'h0, req_port_i.data_rdata[63:56]};
         endcase
     end
 

--- a/src/lsu.sv
+++ b/src/lsu.sv
@@ -15,10 +15,7 @@
 import ariane_pkg::*;
 
 module lsu #(
-        parameter int unsigned ASID_WIDTH       = 1,
-        parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000,
-        parameter int unsigned AXI_ID_WIDTH     = 10,
-        parameter int unsigned AXI_USER_WIDTH   = 1
+        parameter int unsigned ASID_WIDTH       = 1
 )(
     input  logic                     clk_i,
     input  logic                     rst_ni,
@@ -58,14 +55,10 @@ module lsu #(
     // Performance counters
     output logic                     itlb_miss_o,
     output logic                     dtlb_miss_o,
-    output logic                     dcache_miss_o,
-
-    input  logic                     dcache_en_i,
-    input  logic                     flush_dcache_i,
-    output logic                     flush_dcache_ack_o,
-    // Data cache refill port
-    AXI_BUS.Master                   data_if,
-    AXI_BUS.Master                   bypass_if,
+    
+    // interface to dcache
+    input  dcache_req_o_t [2:0]      dcache_req_ports_i,  
+    output dcache_req_i_t [2:0]      dcache_req_ports_o, 
 
     output exception_t               lsu_exception_o   // to WB, signal exception status LD/ST exception
 
@@ -139,74 +132,26 @@ module lsu #(
     assign amo_op_i[0] = AMO_NONE;
     assign amo_op_i[2] = AMO_NONE;
 
-    // decreasing priority
-    // Port 0: PTW
-    // Port 1: Load Unit
-    // Port 2: Store Unit
-    nbdcache #(
-        .CACHE_START_ADDR ( CACHE_START_ADDR ),
-        .AXI_ID_WIDTH     ( AXI_ID_WIDTH     ),
-        .AXI_USER_WIDTH   ( AXI_USER_WIDTH   )
-    ) i_nbdcache (
-        // to D$
-        .data_if           ( data_if                 ),
-        .bypass_if         ( bypass_if               ),
-        .enable_i          ( dcache_en_i             ),
-        .flush_i           ( flush_dcache_i          ),
-        .flush_ack_o       ( flush_dcache_ack_o      ),
-        // from PTW, Load Unit and Store Unit
-        .address_index_i   ( address_index_i         ),
-        .address_tag_i     ( address_tag_i           ),
-        .data_wdata_i      ( data_wdata_i            ),
-        .data_req_i        ( data_req_i              ),
-        .data_we_i         ( data_we_i               ),
-        .data_be_i         ( data_be_i               ),
-        .data_size_i       ( data_size_i             ),
-        .kill_req_i        ( kill_req_i              ),
-        .tag_valid_i       ( tag_valid_i             ),
-        .data_gnt_o        ( data_gnt_o              ),
-        .data_rvalid_o     ( data_rvalid_o           ),
-        .data_rdata_o      ( data_rdata_o            ),
-        .amo_op_i          ( amo_op_i                ),
-
-        .amo_commit_i      (                         ),
-        .amo_valid_o       (                         ),
-        .amo_result_o      (                         ),
-        .amo_flush_i       ( 1'b0                    ),
-        .miss_o            ( dcache_miss_o           ),
-        .*
-    );
-
     // -------------------
     // MMU e.g.: TLBs/PTW
     // -------------------
     mmu #(
-        .INSTR_TLB_ENTRIES      ( 16                   ),
-        .DATA_TLB_ENTRIES       ( 16                   ),
-        .ASID_WIDTH             ( ASID_WIDTH           )
-    ) i_mmu (
-            // misaligned bypass
-        .misaligned_ex_i        ( misaligned_exception ),
-        .lsu_is_store_i         ( st_translation_req   ),
-        .lsu_req_i              ( translation_req      ),
-        .lsu_vaddr_i            ( mmu_vaddr            ),
-        .lsu_valid_o            ( translation_valid    ),
-        .lsu_paddr_o            ( mmu_paddr            ),
-        .lsu_exception_o        ( mmu_exception        ),
-        .lsu_dtlb_hit_o         ( dtlb_hit             ), // send in the same cycle as the request
+        .INSTR_TLB_ENTRIES      ( 16                     ),
+        .DATA_TLB_ENTRIES       ( 16                     ),
+        .ASID_WIDTH             ( ASID_WIDTH             )
+    ) i_mmu (  
+            // misaligned bypass  
+        .misaligned_ex_i        ( misaligned_exception   ),
+        .lsu_is_store_i         ( st_translation_req     ),
+        .lsu_req_i              ( translation_req        ),
+        .lsu_vaddr_i            ( mmu_vaddr              ),
+        .lsu_valid_o            ( translation_valid      ),
+        .lsu_paddr_o            ( mmu_paddr              ),
+        .lsu_exception_o        ( mmu_exception          ),
+        .lsu_dtlb_hit_o         ( dtlb_hit               ), // send in the same cycle as the request
         // connecting PTW to D$ IF (aka mem arbiter
-        .address_index_o        ( address_index_i  [0] ),
-        .address_tag_o          ( address_tag_i    [0] ),
-        .data_wdata_o           ( data_wdata_i     [0] ),
-        .data_req_o             ( data_req_i       [0] ),
-        .data_we_o              ( data_we_i        [0] ),
-        .data_be_o              ( data_be_i        [0] ),
-        .data_size_o            ( data_size_i      [0] ),
-        .kill_req_o             ( kill_req_i       [0] ),
-        .tag_valid_o            ( tag_valid_i      [0] ),
-        .data_gnt_i             ( data_gnt_o       [0] ),
-        .data_rvalid_i          ( data_rvalid_o    [0] ),
-        .data_rdata_i           ( data_rdata_o     [0] ),
+        .req_port_i             ( dcache_req_ports_i [0] ),
+        .req_port_o             ( dcache_req_ports_o [0] ),
         .*
     );
     // ------------------
@@ -231,17 +176,8 @@ module lsu #(
         .page_offset_i         ( page_offset          ),
         .page_offset_matches_o ( page_offset_matches  ),
         // to memory arbiter
-        .address_index_o       ( address_index_i  [2] ),
-        .address_tag_o         ( address_tag_i    [2] ),
-        .data_wdata_o          ( data_wdata_i     [2] ),
-        .data_req_o            ( data_req_i       [2] ),
-        .data_we_o             ( data_we_i        [2] ),
-        .data_be_o             ( data_be_i        [2] ),
-        .data_size_o           ( data_size_i      [2] ),
-        .kill_req_o            ( kill_req_i       [2] ),
-        .tag_valid_o           ( tag_valid_i      [2] ),
-        .data_gnt_i            ( data_gnt_o       [2] ),
-        .data_rvalid_i         ( data_rvalid_o    [2] ),
+        .req_port_i             ( dcache_req_ports_i [2] ),
+        .req_port_o             ( dcache_req_ports_o [2] ),
         .*
     );
 
@@ -267,19 +203,8 @@ module lsu #(
         .page_offset_o         ( page_offset          ),
         .page_offset_matches_i ( page_offset_matches  ),
         // to memory arbiter
-        .address_index_o       ( address_index_i  [1] ),
-        .address_tag_o         ( address_tag_i    [1] ),
-        .data_wdata_o          ( data_wdata_i     [1] ),
-        .amo_op_o              ( amo_op_i         [1] ),
-        .data_req_o            ( data_req_i       [1] ),
-        .data_we_o             ( data_we_i        [1] ),
-        .data_be_o             ( data_be_i        [1] ),
-        .data_size_o           ( data_size_i      [1] ),
-        .kill_req_o            ( kill_req_i       [1] ),
-        .tag_valid_o           ( tag_valid_i      [1] ),
-        .data_gnt_i            ( data_gnt_o       [1] ),
-        .data_rvalid_i         ( data_rvalid_o    [1] ),
-        .data_rdata_i          ( data_rdata_o     [1] ),
+        .req_port_i            ( dcache_req_ports_i [1] ),
+        .req_port_o            ( dcache_req_ports_o [1] ),
         .*
     );
 

--- a/src/lsu.sv
+++ b/src/lsu.sv
@@ -39,11 +39,9 @@ module lsu #(
     input  logic                     enable_translation_i,     // enable virtual memory translation
     input  logic                     en_ld_st_translation_i,   // enable virtual memory translation for load/stores
 
-    input  logic                     fetch_req_i,              // Instruction fetch interface
-    input  logic [63:0]              fetch_vaddr_i,            // Instruction fetch interface
-    output logic                     fetch_valid_o,            // Instruction fetch interface
-    output logic [63:0]              fetch_paddr_o,            // Instruction fetch interface
-    output exception_t               fetch_exception_o,        // Instruction fetch interface
+    // icache translation requests
+    input  icache_areq_o_t           icache_areq_i,         
+    output icache_areq_i_t           icache_areq_o,       
 
     input  priv_lvl_t                priv_lvl_i,               // From CSR register file
     input  priv_lvl_t                ld_st_priv_lvl_i,         // From CSR register file
@@ -152,6 +150,9 @@ module lsu #(
         // connecting PTW to D$ IF (aka mem arbiter
         .req_port_i             ( dcache_req_ports_i [0] ),
         .req_port_o             ( dcache_req_ports_o [0] ),
+        // icache address translation requests
+        .icache_areq_i          ( icache_areq_i          ),
+        .icache_areq_o          ( icache_areq_o          ),
         .*
     );
     // ------------------

--- a/src/lsu_arbiter.sv
+++ b/src/lsu_arbiter.sv
@@ -8,8 +8,9 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 //
-// Author: Florian Zaruba, ETH Zurich
-// Date: 22.05.2017
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
 // Description: Arbitrates the LSU result port
 
 import ariane_pkg::*;
@@ -34,95 +35,101 @@ module lsu_arbiter (
     output logic [63:0]              result_o,
     output exception_t               ex_o
 );
-    // this is a dual input FIFO which takes results from the load and store
-    // paths of the LSU and sequentializes through the FIFO construct. If there is a valid output
-    // it unconditionally posts the result on its output ports and expects it to be consumed.
 
-    // 4 entries is enough to unconditionally post loads and stores since we can only have two outstanding loads
-    localparam int WIDTH = 4;
+    // the two fifos are used to buffer results from ld and st paths, and arbits between these results in
+    // RR fashion. FIFOs need to be 2 deep in order to unconditionally accept loads and stores since we can
+    // have a maximum of 2 outstanding loads.
+    // if there are valid elements in the fifos, the unit posts the result on its output ports and expects it
+    // to be consumed unconditionally 
 
-    // queue pointer
-    logic [$clog2(WIDTH)-1:0] read_pointer_n,  read_pointer_q;
-    logic [$clog2(WIDTH)-1:0] write_pointer_n, write_pointer_q;
-    logic [$clog2(WIDTH)-1:0] status_cnt_n,    status_cnt_q;
+    localparam int DEPTH = 2;
 
-    struct packed {
+    typedef struct packed {
         logic [TRANS_ID_BITS-1:0] trans_id;
         logic [63:0]              result;
         exception_t               ex;
-    } mem_n[WIDTH-1:0], mem_q[WIDTH-1:0];
+    } fifo_t;
 
-    // output last element of queue
-    assign trans_id_o = mem_q[read_pointer_q].trans_id;
-    assign result_o   = mem_q[read_pointer_q].result;
-    assign ex_o       = mem_q[read_pointer_q].ex;
+    fifo_t st_in, st_out, ld_in, ld_out;
 
-    // if we are not empty we have a valid output
-    assign valid_o    = (status_cnt_q != '0);
-    // -------------------
-    // Read-Write Process
-    // -------------------
-    always_comb begin : read_write_fifo
-        automatic logic [$clog2(WIDTH)-1:0] status_cnt;
-        automatic logic [$clog2(WIDTH)-1:0] write_pointer;
+    logic ld_full, ld_empty, ld_ren;
+    logic st_full, st_empty, st_ren;
+    logic rrstate_q, rrstate_d;
 
-        status_cnt    = status_cnt_q;
-        write_pointer = write_pointer_q;
+    assign st_in.trans_id = st_trans_id_i;
+    assign st_in.result   = st_result_i;
+    assign st_in.ex       = st_ex_i;
 
-        // default assignments
-        mem_n           = mem_q;
-        read_pointer_n  = read_pointer_q;
-        // ------------
-        // Write Port
-        // ------------
-        // write port 1 - load unit
-        if (ld_valid_i) begin
-            mem_n[write_pointer] = {ld_trans_id_i, ld_result_i, ld_ex_i};
-            write_pointer++;
-            status_cnt++;
-        end
-        // write port 2 - store unit
-        if (st_valid_i) begin
-            mem_n[write_pointer] = {st_trans_id_i, st_result_i, st_ex_i};
-            write_pointer++;
-            status_cnt++;
-        end
-        // ------------
-        // Read Port
-        // ------------
-        // if the last element in the queue was valid we can push it out and make space for a new element
-        if (valid_o) begin
-            read_pointer_n = read_pointer_q + 1;
-            status_cnt--;
-        end
+    assign ld_in.trans_id = ld_trans_id_i;
+    assign ld_in.result   = ld_result_i;
+    assign ld_in.ex       = ld_ex_i;
 
-        // update status count
-        status_cnt_n    = status_cnt;
-        // update write pointer
-        write_pointer_n = write_pointer;
+    assign trans_id_o     = (st_ren) ? st_out.trans_id : ld_out.trans_id; 
+    assign result_o       = (st_ren) ? st_out.result   : ld_out.result;   
+    assign ex_o           = (st_ren) ? st_out.ex       : ld_out.ex;      
 
-        // ------------
-        // Flush
-        // ------------
-        if (flush_i) begin
-            status_cnt_n    = '0;
-            write_pointer_n = '0;
-            read_pointer_n  = '0;
-        end
-    end
-    // sequential process
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-            mem_q           <= '{default: 0};
-            read_pointer_q  <= '0;
-            write_pointer_q <= '0;
-            status_cnt_q    <= '0;
+    assign valid_o        = (~ld_empty) | (~st_empty);
+
+    // round robin with "lookahead" for 2 requesters
+    assign ld_ren         = ((~rrstate_q) | ( rrstate_q & st_empty)) & ~ld_empty;
+    assign st_ren         = (( rrstate_q) | (~rrstate_q & ld_empty)) & ~st_empty;
+
+    assign rrstate_d      = (valid_o) ? ~st_ren : rrstate_q;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+        if(~rst_ni) begin
+            rrstate_q <= 0;
         end else begin
-            mem_q           <= mem_n;
-            read_pointer_q  <= read_pointer_n;
-            write_pointer_q <= write_pointer_n;
-            status_cnt_q    <= status_cnt_n;
+            rrstate_q <= rrstate_d;
         end
     end
+
+    fifo #(
+        .dtype             (  fifo_t     ),
+        .DEPTH             (  DEPTH      )
+    ) ld_fifo (       
+        .clk_i             (  clk_i      ),
+        .rst_ni            (  rst_ni     ),
+        .flush_i           (  flush_i    ),
+        .testmode_i        (  1'b0       ),
+        .full_o            (  ld_full    ),
+        .empty_o           (  ld_empty   ),
+        .alm_full_o        (             ),
+        .alm_empty_o       (             ),
+        .data_i            (  ld_in      ),
+        .push_i            (  ld_valid_i ),
+        .data_o            (  ld_out     ),
+        .pop_i             (  ld_ren     )
+    );  
+
+    fifo #(
+        .dtype             (  fifo_t     ),
+        .DEPTH             (  DEPTH      )
+    ) st_fifo (       
+        .clk_i             (  clk_i      ),
+        .rst_ni            (  rst_ni     ),
+        .flush_i           (  flush_i    ),
+        .testmode_i        (  1'b0       ),
+        .full_o            (  st_full    ),
+        .empty_o           (  st_empty   ),
+        .alm_full_o        (             ),
+        .alm_empty_o       (             ),
+        .data_i            (  st_in      ),
+        .push_i            (  st_valid_i ),
+        .data_o            (  st_out     ),
+        .pop_i             (  st_ren     )
+    ); 
+
+
+`ifndef SYNTHESIS
+`ifndef VERILATOR
+    // check fifo control signals
+    assert property (@(posedge clk_i) disable iff (~rst_ni) ld_full |-> !ld_valid_i) else $fatal ("cannot write full ld_fifo");
+    assert property (@(posedge clk_i) disable iff (~rst_ni) st_full |-> !st_valid_i) else $fatal ("cannot write full st_fifo");
+    assert property (@(posedge clk_i) disable iff (~rst_ni) ld_empty |-> !ld_ren)    else $fatal ("cannot read empty ld_fifo");
+    assert property (@(posedge clk_i) disable iff (~rst_ni) st_empty |-> !st_ren)    else $fatal ("cannot read empty st_fifo");
+`endif
+`endif
+
 
 endmodule

--- a/src/miss_handler.sv
+++ b/src/miss_handler.sv
@@ -15,7 +15,8 @@
 // --------------
 // MISS Handler
 // --------------
-import nbdcache_pkg::*;
+import ariane_pkg::*;
+import std_cache_pkg::*;
 
 module miss_handler #(
     parameter int unsigned NR_PORTS         = 3,

--- a/src/miss_handler.sv
+++ b/src/miss_handler.sv
@@ -48,12 +48,12 @@ module miss_handler #(
     output logic [NR_PORTS-1:0]                         mshr_addr_matches_o,
     output logic [NR_PORTS-1:0]                         mshr_index_matches_o,
     // Port to SRAMs, for refill and eviction
-    output logic  [SET_ASSOCIATIVITY-1:0]               req_o,
-    output logic  [INDEX_WIDTH-1:0]                     addr_o, // address into cache array
+    output logic  [DCACHE_SET_ASSOC-1:0]                req_o,
+    output logic  [DCACHE_INDEX_WIDTH-1:0]              addr_o, // address into cache array
     input  logic                                        gnt_i,
     output cache_line_t                                 data_o,
     output cl_be_t                                      be_o,
-    input  cache_line_t [SET_ASSOCIATIVITY-1:0]         data_i,
+    input  cache_line_t [DCACHE_SET_ASSOC-1:0]          data_i,
     output logic                                        we_o
 );
 
@@ -75,8 +75,8 @@ module miss_handler #(
                        REQ_CACHELINE, MISS_REPL, SAVE_CACHELINE, INIT } state_d, state_q;
     // Registers
     mshr_t                                  mshr_d, mshr_q;
-    logic [INDEX_WIDTH-1:0]                 cnt_d, cnt_q;
-    logic [SET_ASSOCIATIVITY-1:0]           evict_way_d, evict_way_q;
+    logic [DCACHE_INDEX_WIDTH-1:0]                 cnt_d, cnt_q;
+    logic [DCACHE_SET_ASSOC-1:0]           evict_way_d, evict_way_q;
     // cache line to evict
     cache_line_t                            evict_cl_d, evict_cl_q;
 
@@ -93,25 +93,25 @@ module miss_handler #(
     logic                                   req_fsm_miss_valid;
     logic                                   req_fsm_miss_bypass;
     logic [63:0]                            req_fsm_miss_addr;
-    logic [CACHE_LINE_WIDTH-1:0]            req_fsm_miss_wdata;
+    logic [DCACHE_LINE_WIDTH-1:0]            req_fsm_miss_wdata;
     logic                                   req_fsm_miss_we;
-    logic [(CACHE_LINE_WIDTH/8)-1:0]        req_fsm_miss_be;
+    logic [(DCACHE_LINE_WIDTH/8)-1:0]        req_fsm_miss_be;
     logic                                   gnt_miss_fsm;
     logic                                   valid_miss_fsm;
-    logic [(CACHE_LINE_WIDTH/64)-1:0][63:0] data_miss_fsm;
+    logic [(DCACHE_LINE_WIDTH/64)-1:0][63:0] data_miss_fsm;
 
     // Cache Management <-> LFSR
     logic                                   lfsr_enable;
-    logic [SET_ASSOCIATIVITY-1:0]           lfsr_oh;
-    logic [$clog2(SET_ASSOCIATIVITY-1)-1:0] lfsr_bin;
+    logic [DCACHE_SET_ASSOC-1:0]           lfsr_oh;
+    logic [$clog2(DCACHE_SET_ASSOC-1)-1:0] lfsr_bin;
 
     // ------------------------------
     // Cache Management
     // ------------------------------
     always_comb begin : cache_management
-        automatic logic [SET_ASSOCIATIVITY-1:0] evict_way, valid_way;
+        automatic logic [DCACHE_SET_ASSOC-1:0] evict_way, valid_way;
 
-        for (int unsigned i = 0; i < SET_ASSOCIATIVITY; i++) begin
+        for (int unsigned i = 0; i < DCACHE_SET_ASSOC; i++) begin
             evict_way[i] = data_i[i].valid & data_i[i].dirty;
             valid_way[i] = data_i[i].valid;
         end
@@ -170,7 +170,7 @@ module miss_handler #(
                         mshr_d.valid = 1'b1;
                         mshr_d.we    = miss_req_we[i];
                         mshr_d.id    = i;
-                        mshr_d.addr  = miss_req_addr[i][TAG_WIDTH+INDEX_WIDTH-1:0];
+                        mshr_d.addr  = miss_req_addr[i][DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:0];
                         mshr_d.wdata = miss_req_wdata[i];
                         mshr_d.be    = miss_req_be[i];
                         break;
@@ -183,7 +183,7 @@ module miss_handler #(
                 // 1. Check if there is an empty cache-line
                 // 2. If not -> evict one
                 req_o = '1;
-                addr_o = mshr_q.addr[INDEX_WIDTH-1:0];
+                addr_o = mshr_q.addr[DCACHE_INDEX_WIDTH-1:0];
                 state_d = MISS_REPL;
                 miss_o = 1'b1;
             end
@@ -199,7 +199,7 @@ module miss_handler #(
                         state_d = WB_CACHELINE_MISS;
                         evict_cl_d.tag = data_i[lfsr_bin].tag;
                         evict_cl_d.data = data_i[lfsr_bin].data;
-                        cnt_d = mshr_q.addr[INDEX_WIDTH-1:0];
+                        cnt_d = mshr_q.addr[DCACHE_INDEX_WIDTH-1:0];
                     // no - we can request a cache line now
                     end else
                         state_d = REQ_CACHELINE;
@@ -225,18 +225,18 @@ module miss_handler #(
             // ~> replace the cacheline
             SAVE_CACHELINE: begin
                 // calculate cacheline offset
-                automatic logic [$clog2(CACHE_LINE_WIDTH)-1:0] cl_offset;
-                cl_offset = mshr_q.addr[BYTE_OFFSET-1:3] << 6;
+                automatic logic [$clog2(DCACHE_LINE_WIDTH)-1:0] cl_offset;
+                cl_offset = mshr_q.addr[DCACHE_BYTE_OFFSET-1:3] << 6;
                 // we've got a valid response from refill unit
                 if (valid_miss_fsm) begin
 
-                    addr_o       = mshr_q.addr[INDEX_WIDTH-1:0];
+                    addr_o       = mshr_q.addr[DCACHE_INDEX_WIDTH-1:0];
                     req_o        = evict_way_q;
                     we_o         = 1'b1;
                     be_o         = '1;
                     be_o.valid   = evict_way_q;
                     be_o.dirty   = evict_way_q;
-                    data_o.tag   = mshr_q.addr[TAG_WIDTH+INDEX_WIDTH-1:INDEX_WIDTH];
+                    data_o.tag   = mshr_q.addr[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_INDEX_WIDTH];
                     data_o.data  = data_miss_fsm;
                     data_o.valid = 1'b1;
                     data_o.dirty = 1'b0;
@@ -266,7 +266,7 @@ module miss_handler #(
             WB_CACHELINE_FLUSH, WB_CACHELINE_MISS: begin
 
                 req_fsm_miss_valid  = 1'b1;
-                req_fsm_miss_addr   = {evict_cl_q.tag, cnt_q[INDEX_WIDTH-1:BYTE_OFFSET], {{BYTE_OFFSET}{1'b0}}};
+                req_fsm_miss_addr   = {evict_cl_q.tag, cnt_q[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET], {{DCACHE_BYTE_OFFSET}{1'b0}}};
                 req_fsm_miss_be     = '1;
                 req_fsm_miss_we     = 1'b1;
                 req_fsm_miss_wdata  = evict_cl_q.data;
@@ -306,14 +306,14 @@ module miss_handler #(
                 // not dirty ~> increment and continue
                 end else begin
                     // increment and re-request
-                    cnt_d      = cnt_q + (1'b1 << BYTE_OFFSET);
+                    cnt_d      = cnt_q + (1'b1 << DCACHE_BYTE_OFFSET);
                     state_d    = FLUSH_REQ_STATUS;
                     addr_o     = cnt_q;
                     req_o      = 1'b1;
                     be_o.valid = '1;
                     we_o       = 1'b1;
                     // finished with flushing operation, go back to idle
-                    if (cnt_q[INDEX_WIDTH-1:BYTE_OFFSET] == NUM_WORDS-1) begin
+                    if (cnt_q[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET] == DCACHE_NUM_WORDS-1) begin
                         flush_ack_o = 1'b1;
                         state_d     = IDLE;
                     end
@@ -329,9 +329,9 @@ module miss_handler #(
                 // only write the dirty array
                 be_o.dirty = '1;
                 be_o.valid = '1;
-                cnt_d      = cnt_q + (1'b1 << BYTE_OFFSET);
+                cnt_d      = cnt_q + (1'b1 << DCACHE_BYTE_OFFSET);
                 // finished initialization
-                if (cnt_q[INDEX_WIDTH-1:BYTE_OFFSET] == NUM_WORDS-1)
+                if (cnt_q[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET] == DCACHE_NUM_WORDS-1)
                     state_d = IDLE;
             end
         endcase
@@ -345,12 +345,12 @@ module miss_handler #(
 
         for (int i = 0; i < NR_PORTS; i++) begin
             // check mshr for potential matching of other units, exclude the unit currently being served
-            if (mshr_q.valid && mshr_addr_i[i][55:BYTE_OFFSET] == mshr_q.addr[55:BYTE_OFFSET]) begin
+            if (mshr_q.valid && mshr_addr_i[i][55:DCACHE_BYTE_OFFSET] == mshr_q.addr[55:DCACHE_BYTE_OFFSET]) begin
                 mshr_addr_matches_o[i] = 1'b1;
             end
 
             // same as previous, but checking only the index
-            if (mshr_q.valid && mshr_addr_i[i][INDEX_WIDTH-1:BYTE_OFFSET] == mshr_q.addr[INDEX_WIDTH-1:BYTE_OFFSET]) begin
+            if (mshr_q.valid && mshr_addr_i[i][DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET] == mshr_q.addr[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET]) begin
                 mshr_index_matches_o[i] = 1'b1;
             end
         end
@@ -455,7 +455,7 @@ module miss_handler #(
     // Cache Line Arbiter
     // ----------------------
     axi_adapter  #(
-        .DATA_WIDTH          ( CACHE_LINE_WIDTH   ),
+        .DATA_WIDTH          ( DCACHE_LINE_WIDTH   ),
         .AXI_ID_WIDTH        ( AXI_ID_WIDTH       )
     ) i_miss_axi_adapter (
         .req_i               ( req_fsm_miss_valid ),
@@ -478,7 +478,7 @@ module miss_handler #(
     // -----------------
     // Replacement LFSR
     // -----------------
-    lfsr #(.WIDTH (SET_ASSOCIATIVITY)) i_lfsr (
+    lfsr #(.WIDTH (DCACHE_SET_ASSOC)) i_lfsr (
         .en_i           ( lfsr_enable ),
         .refill_way_oh  ( lfsr_oh     ),
         .refill_way_bin ( lfsr_bin    ),
@@ -717,7 +717,7 @@ module axi_adapter #(
         axi.ar_valid  = 1'b0;
         // in case of a single request or wrapping transfer we can simply begin at the address, if we want to request a cache-line
         // with an incremental transfer we need to output the corresponding base address of the cache line
-        axi.ar_addr   = (CRITICAL_WORD_FIRST || type_i == SINGLE_REQ) ? addr_i : { addr_i[63:BYTE_OFFSET], {{BYTE_OFFSET}{1'b0}}};
+        axi.ar_addr   = (CRITICAL_WORD_FIRST || type_i == SINGLE_REQ) ? addr_i : { addr_i[63:DCACHE_BYTE_OFFSET], {{DCACHE_BYTE_OFFSET}{1'b0}}};
         axi.ar_prot   = 3'b0;
         axi.ar_region = 4'b0;
         axi.ar_len    = 8'b0;

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -26,14 +26,9 @@ module mmu #(
         input  logic                            flush_i,
         input  logic                            enable_translation_i,
         input  logic                            en_ld_st_translation_i,   // enable virtual memory translation for load/stores
-
         // IF interface
-        input  logic                            fetch_req_i,
-        input  logic [63:0]                     fetch_vaddr_i,
-        output logic                            fetch_valid_o,     // translation is valid
-        output logic [63:0]                     fetch_paddr_o,
-        output exception_t                      fetch_exception_o, // write-back fetch exceptions (e.g.: bus faults, page faults, etc.)
-
+        input  icache_areq_o_t                  icache_areq_i,         
+        output icache_areq_i_t                  icache_areq_o, 
         // LSU interface
         // this is a more minimalistic interface because the actual addressing logic is handled
         // in the LSU as we distinguish load and stores, what we do here is simple address translation
@@ -91,7 +86,7 @@ module mmu #(
 
 
     // Assignments
-    assign itlb_lu_access = fetch_req_i;
+    assign itlb_lu_access = icache_areq_i.fetch_req;
     assign dtlb_lu_access = lsu_req_i;
 
 
@@ -107,7 +102,7 @@ module mmu #(
 
         .lu_access_i      ( itlb_lu_access             ),
         .lu_asid_i        ( asid_i                     ),
-        .lu_vaddr_i       ( fetch_vaddr_i              ),
+        .lu_vaddr_i       ( icache_areq_i.fetch_vaddr              ),
         .lu_content_o     ( itlb_content               ),
 
         .lu_is_2M_o       ( itlb_is_2M                 ),
@@ -153,7 +148,7 @@ module mmu #(
 
         .itlb_access_i          ( itlb_lu_access        ),
         .itlb_hit_i             ( itlb_lu_hit           ),
-        .itlb_vaddr_i           ( fetch_vaddr_i         ),
+        .itlb_vaddr_i           ( icache_areq_i.fetch_vaddr         ),
 
         .dtlb_access_i          ( dtlb_lu_access        ),
         .dtlb_hit_i             ( dtlb_lu_hit           ),
@@ -171,36 +166,36 @@ module mmu #(
     // The instruction interface is a simple request response interface
     always_comb begin : instr_interface
         // MMU disabled: just pass through
-        fetch_valid_o  = fetch_req_i;
-        fetch_paddr_o  = fetch_vaddr_i; // play through in case we disabled address translation
+        icache_areq_o.fetch_valid  = icache_areq_i.fetch_req;
+        icache_areq_o.fetch_paddr  = icache_areq_i.fetch_vaddr; // play through in case we disabled address translation
         // two potential exception sources:
         // 1. HPTW threw an exception -> signal with a page fault exception
         // 2. We got an access error because of insufficient permissions -> throw an access exception
-        fetch_exception_o      = '0;
+        icache_areq_o.fetch_exception      = '0;
         // Check whether we are allowed to access this memory region from a fetch perspective
-        iaccess_err   = fetch_req_i && (((priv_lvl_i == PRIV_LVL_U) && ~itlb_content.u)
+        iaccess_err   = icache_areq_i.fetch_req && (((priv_lvl_i == PRIV_LVL_U) && ~itlb_content.u)
                                      || ((priv_lvl_i == PRIV_LVL_S) && itlb_content.u));
 
         // check that the upper-most bits (63-39) are the same, otherwise throw a page fault exception...
-        if (fetch_req_i && !((&fetch_vaddr_i[63:39]) == 1'b1 || (|fetch_vaddr_i[63:39]) == 1'b0)) begin
-            fetch_exception_o = {INSTR_PAGE_FAULT, fetch_vaddr_i, 1'b1};
+        if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[63:39]) == 1'b1 || (|icache_areq_i.fetch_vaddr[63:39]) == 1'b0)) begin
+            icache_areq_o.fetch_exception = {INSTR_PAGE_FAULT, icache_areq_i.fetch_vaddr, 1'b1};
         end
         // MMU enabled: address from TLB, request delayed until hit. Error when TLB
         // hit and no access right or TLB hit and translated address not valid (e.g.
         // AXI decode error), or when PTW performs walk due to ITLB miss and raises
         // an error.
         if (enable_translation_i) begin
-            fetch_valid_o = 1'b0;
+            icache_areq_o.fetch_valid = 1'b0;
 
             // 4K page
-            fetch_paddr_o = {itlb_content.ppn, fetch_vaddr_i[11:0]};
+            icache_areq_o.fetch_paddr = {itlb_content.ppn, icache_areq_i.fetch_vaddr[11:0]};
             // Mega page
             if (itlb_is_2M) begin
-                fetch_paddr_o[20:12] = fetch_vaddr_i[20:12];
+                icache_areq_o.fetch_paddr[20:12] = icache_areq_i.fetch_vaddr[20:12];
             end
             // Giga page
             if (itlb_is_1G) begin
-                fetch_paddr_o[29:12] = fetch_vaddr_i[29:12];
+                icache_areq_o.fetch_paddr[29:12] = icache_areq_i.fetch_vaddr[29:12];
             end
 
             // ---------
@@ -208,11 +203,11 @@ module mmu #(
             // --------
             // if we hit the ITLB output the request signal immediately
             if (itlb_lu_hit) begin
-                fetch_valid_o = fetch_req_i;
+                icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
                 // we got an access error
                 if (iaccess_err) begin
                     // throw a page fault
-                    fetch_exception_o = {INSTR_PAGE_FAULT, fetch_vaddr_i, 1'b1};
+                    icache_areq_o.fetch_exception = {INSTR_PAGE_FAULT, icache_areq_i.fetch_vaddr, 1'b1};
                 end
             end else
             // ---------
@@ -220,8 +215,8 @@ module mmu #(
             // ---------
             // watch out for exceptions happening during walking the page table
             if (ptw_active && walking_instr) begin
-                fetch_valid_o = ptw_error;
-                fetch_exception_o = {INSTR_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
+                icache_areq_o.fetch_valid = ptw_error;
+                icache_areq_o.fetch_exception = {INSTR_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
             end
         end
     end

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -60,19 +60,9 @@ module mmu #(
         // Performance counters
         output logic                            itlb_miss_o,
         output logic                            dtlb_miss_o,
-        // PTW memory interface
-        output logic [11:0]                     address_index_o,
-        output logic [43:0]                     address_tag_o,
-        output logic [63:0]                     data_wdata_o,
-        output logic                            data_req_o,
-        output logic                            data_we_o,
-        output logic [7:0]                      data_be_o,
-        output logic [1:0]                      data_size_o,
-        output logic                            kill_req_o,
-        output logic                            tag_valid_o,
-        input  logic                            data_gnt_i,
-        input  logic                            data_rvalid_i,
-        input  logic [63:0]                     data_rdata_i
+        // PTW memory interface 
+        input  dcache_req_o_t                   req_port_i,
+        output dcache_req_i_t                   req_port_o  
 );
 
     logic        iaccess_err;   // insufficient privilege to access this instruction page
@@ -99,9 +89,11 @@ module mmu #(
     logic        dtlb_is_1G;
     logic        dtlb_lu_hit;
 
+
     // Assignments
     assign itlb_lu_access = fetch_req_i;
     assign dtlb_lu_access = lsu_req_i;
+
 
     tlb #(
         .TLB_ENTRIES      ( INSTR_TLB_ENTRIES          ),
@@ -166,6 +158,10 @@ module mmu #(
         .dtlb_access_i          ( dtlb_lu_access        ),
         .dtlb_hit_i             ( dtlb_lu_hit           ),
         .dtlb_vaddr_i           ( lsu_vaddr_i           ),
+                
+        .req_port_i            ( req_port_i             ),
+        .req_port_o            ( req_port_o             ),
+
         .*
      );
 

--- a/src/nbdcache.sv
+++ b/src/nbdcache.sv
@@ -13,7 +13,7 @@
 // Description: Nonblocking private L1 dcache
 
 import ariane_pkg::*;
-import nbdcache_pkg::*;
+import std_cache_pkg::*;
 
 module nbdcache #(
         parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000,
@@ -36,19 +36,8 @@ module nbdcache #(
     output logic [63:0]                    amo_result_o, // result of atomic memory operation
     input  logic                           amo_flush_i,  // forget about AMO
     // Request ports
-    input  logic [2:0][INDEX_WIDTH-1:0]    address_index_i,
-    input  logic [2:0][TAG_WIDTH-1:0]      address_tag_i,
-    input  logic [2:0][63:0]               data_wdata_i,
-    input  logic [2:0]                     data_req_i,
-    input  logic [2:0]                     data_we_i,
-    input  logic [2:0][7:0]                data_be_i,
-    input  logic [2:0][1:0]                data_size_i,
-    input  logic [2:0]                     kill_req_i,
-    input  logic [2:0]                     tag_valid_i,
-    output logic [2:0]                     data_gnt_o,
-    output logic [2:0]                     data_rvalid_o,
-    output logic [2:0][63:0]               data_rdata_o,
-    input  amo_t [2:0]                     amo_op_i
+    input  dcache_req_i_t [2:0]            req_ports_i,  // request ports
+    output dcache_req_o_t [2:0]            req_ports_o   // request ports 
 );
 
     // -------------------------------
@@ -101,27 +90,19 @@ module nbdcache #(
     generate
         for (genvar i = 0; i < 3; i++) begin : master_ports
             cache_ctrl  #(
-                .SET_ASSOCIATIVITY     ( SET_ASSOCIATIVITY    ),
-                .INDEX_WIDTH           ( INDEX_WIDTH          ),
-                .TAG_WIDTH             ( TAG_WIDTH            ),
-                .CACHE_LINE_WIDTH      ( CACHE_LINE_WIDTH     ),
+                // .SET_ASSOCIATIVITY     ( SET_ASSOCIATIVITY    ),
+                // .INDEX_WIDTH           ( INDEX_WIDTH          ),
+                // .TAG_WIDTH             ( TAG_WIDTH            ),
+                // .CACHE_LINE_WIDTH      ( CACHE_LINE_WIDTH     ),
                 .CACHE_START_ADDR      ( CACHE_START_ADDR     )
             ) i_cache_ctrl (
                 .bypass_i              ( ~enable_i            ),
+
                 .busy_o                ( busy            [i]  ),
-                .address_index_i       ( address_index_i [i]  ),
-                .address_tag_i         ( address_tag_i   [i]  ),
-                .data_wdata_i          ( data_wdata_i    [i]  ),
-                .data_req_i            ( data_req_i      [i]  ),
-                .data_we_i             ( data_we_i       [i]  ),
-                .data_be_i             ( data_be_i       [i]  ),
-                .data_size_i           ( data_size_i     [i]  ),
-                .kill_req_i            ( kill_req_i      [i]  ),
-                .tag_valid_i           ( tag_valid_i     [i]  ),
-                .data_gnt_o            ( data_gnt_o      [i]  ),
-                .data_rvalid_o         ( data_rvalid_o   [i]  ),
-                .data_rdata_o          ( data_rdata_o    [i]  ),
-                .amo_op_i              ( amo_op_i        [i]  ),
+
+                .req_port_i            ( req_ports_i     [i]  ),
+                .req_port_o            ( req_ports_o     [i]  ),
+
 
                 .req_o                 ( req            [i+1] ),
                 .addr_o                ( addr           [i+1] ),

--- a/src/ptw.sv
+++ b/src/ptw.sv
@@ -32,19 +32,11 @@ module ptw #(
     input  logic                    en_ld_st_translation_i, // enable virtual memory translation for load/stores
 
     input  logic                    lsu_is_store_i,         // this translation was triggered by a store
-    // PTW Memory Port
-    output logic [11:0]             address_index_o,
-    output logic [43:0]             address_tag_o,
-    output logic [63:0]             data_wdata_o,
-    output logic                    data_req_o,
-    output logic                    data_we_o,
-    output logic [7:0]              data_be_o,
-    output logic [1:0]              data_size_o,
-    output logic                    kill_req_o,
-    output logic                    tag_valid_o,
-    input  logic                    data_gnt_i,
-    input  logic                    data_rvalid_i,
-    input  logic [63:0]             data_rdata_i,
+    // PTW memory interface 
+    input  dcache_req_o_t           req_port_i,
+    output dcache_req_i_t           req_port_o,
+
+
     // to TLBs, update logic
     output tlb_update_t             itlb_update_o,
     output tlb_update_t             dtlb_update_o,
@@ -69,6 +61,9 @@ module ptw #(
     output logic                    dtlb_miss_o
 
 );
+
+    assign req_port_o.amo_op = AMO_NONE;
+
     // input registers
     logic data_rvalid_q;
     logic [63:0] data_rdata_q;
@@ -107,12 +102,12 @@ module ptw #(
     assign ptw_active_o    = (CS != IDLE);
     assign walking_instr_o = is_instr_ptw_q;
     // directly output the correct physical address
-    assign address_index_o = ptw_pptr_q[11:0];
-    assign address_tag_o   = ptw_pptr_q[55:12];
+    assign req_port_o.address_index = ptw_pptr_q[11:0];
+    assign req_port_o.address_tag   = ptw_pptr_q[55:12];
     // we are never going to kill this request
-    assign kill_req_o      = '0;
+    assign req_port_o.kill_req      = '0;
     // we are never going to write with the HPTW
-    assign data_wdata_o    = 64'b0;
+    assign req_port_o.data_wdata    = 64'b0;
     // -----------
     // TLB Update
     // -----------
@@ -130,7 +125,7 @@ module ptw #(
     assign itlb_update_o.content = pte | (global_mapping_q << 5);
     assign dtlb_update_o.content = pte | (global_mapping_q << 5);
 
-    assign tag_valid_o      = tag_valid_q;
+    assign req_port_o.tag_valid      = tag_valid_q;
 
     //-------------------
     // Page table walker
@@ -159,10 +154,10 @@ module ptw #(
         // default assignments
         // PTW memory interface
         tag_valid_n         = 1'b0;
-        data_req_o          = 1'b0;
-        data_be_o           = 8'hFF;
-        data_size_o         = 2'b11;
-        data_we_o           = 1'b0;
+        req_port_o.data_req          = 1'b0;
+        req_port_o.data_be           = 8'hFF;
+        req_port_o.data_size         = 2'b11;
+        req_port_o.data_we           = 1'b0;
         ptw_error_o         = 1'b0;
         itlb_update_o.valid = 1'b0;
         dtlb_update_o.valid = 1'b0;
@@ -206,9 +201,9 @@ module ptw #(
 
             WAIT_GRANT: begin
                 // send a request out
-                data_req_o = 1'b1;
+                req_port_o.data_req = 1'b1;
                 // wait for the WAIT_GRANT
-                if (data_gnt_i) begin
+                if (req_port_i.data_gnt) begin
                     // send the tag valid signal one cycle later
                     tag_valid_n = 1'b1;
                     NS          = PTE_LOOKUP;
@@ -333,7 +328,7 @@ module ptw #(
             // 1. in the PTE Lookup check whether we still need to wait for an rvalid
             // 2. waiting for a grant, if so: wait for it
             // if not, go back to idle
-            if ((CS == PTE_LOOKUP && !data_rvalid_q) || ((CS == WAIT_GRANT) && data_gnt_i))
+            if ((CS == PTE_LOOKUP && !data_rvalid_q) || ((CS == WAIT_GRANT) && req_port_i.data_gnt))
                 NS = WAIT_RVALID;
             else
                 NS = IDLE;
@@ -362,8 +357,8 @@ module ptw #(
             tlb_update_asid_q  <= tlb_update_asid_n;
             vaddr_q            <= vaddr_n;
             global_mapping_q   <= global_mapping_n;
-            data_rdata_q       <= data_rdata_i;
-            data_rvalid_q      <= data_rvalid_i;
+            data_rdata_q       <= req_port_i.data_rdata;
+            data_rvalid_q      <= req_port_i.data_rvalid;
         end
     end
 

--- a/src/rrarbiter.sv
+++ b/src/rrarbiter.sv
@@ -1,0 +1,161 @@
+// Copyright (c) 2018 ETH Zurich, University of Bologna
+// All rights reserved.
+//
+// This code is under development and not yet released to the public.
+// Until it is released, the code is under the copyright of ETH Zurich and
+// the University of Bologna, and may contain confidential and/or unpublished
+// work. Any reuse/redistribution is strictly forbidden without written
+// permission from ETH Zurich.
+//
+// Bug fixes and contributions will eventually be released under the
+// SolderPad open hardware license in the context of the PULP platform
+// (http://www.pulp-platform.org), under the copyright of ETH Zurich and the
+// University of Bologna.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 16.08.2018
+// Description: Round robin arbiter with lookahead
+//  
+// this unit is a generic round robin arbiter with "look ahead" - i.e. it jumps 
+// to the next valid request signal instead of stepping around with stepsize 1. 
+// if the current req signal has been acknowledged in the last cycle, and it is 
+// again valid in the current cycle, the arbiter will first serve the other req 
+// signals (if there is a valid one) in the req vector before acknowledging the 
+// same signal again (this prevents starvation).
+//
+// the arbiter has a request signal vector input (req_i) and an ack 
+// signal vector ouput (ack_o). to enable the arbiter the signal 
+// en_i has to be asserted. vld_o is high when one of the 
+// req_i signals is acknowledged.
+//
+// the entity has one register which stores the index of the last request signal 
+// that was served.
+// 
+// dependencies: relies on fast leading zero counter tree "ff1" in common_cells
+//
+
+module rrarbiter #(
+    parameter NUM_REQ = 13
+)(
+    input logic                         clk_i,
+    input logic                         rst_ni,
+ 
+    input logic                         flush_i, // clears the fsm and control signal registers 
+    input logic                         en_i,    // arbiter enable
+    input logic [NUM_REQ-1:0]           req_i,   // request signals
+ 
+    output logic [NUM_REQ-1:0]          ack_o,   // acknowledge signals
+    output logic                        vld_o,   // valid signals
+    output logic [$clog2(NUM_REQ)-1:0]  idx_o    // idx output
+    );
+
+localparam SEL_WIDTH = $clog2(NUM_REQ);
+
+logic [SEL_WIDTH-1:0] arb_sel_d;
+logic [SEL_WIDTH-1:0] arb_sel_q;        
+
+
+// only used in case of more than 2 requesters
+logic [NUM_REQ-1:0] mask_lut[NUM_REQ-1:0];
+logic [NUM_REQ-1:0] mask;
+logic [NUM_REQ-1:0] masked_lower;
+logic [NUM_REQ-1:0] masked_upper;
+logic [SEL_WIDTH-1:0] lower_idx;
+logic [SEL_WIDTH-1:0] upper_idx;
+logic [SEL_WIDTH-1:0] next_idx;
+logic [SEL_WIDTH-1:0] idx;
+logic no_lower_ones;
+
+
+// shared
+assign idx_o          = arb_sel_d;
+assign vld_o          = (|req_i) & en_i;
+
+// only 2 input requesters
+generate 
+    if (NUM_REQ == 2) begin
+
+        assign ack_o[0]       = ((~arb_sel_q) | ( arb_sel_q & ~req_i[1])) & req_i[0] & en_i;
+        assign arb_sel_d      = (( arb_sel_q) | (~arb_sel_q & ~req_i[0])) & req_i[1];
+        assign ack_o[1]       = arb_sel_d                                            & en_i;
+    
+    end    
+endgenerate        
+
+// more than 2 requesters
+generate 
+    if (NUM_REQ > 2) begin
+
+        // this mask is used to mask the incoming req vector 
+        // depending on the index of the last served index
+        assign mask = mask_lut[arb_sel_q];
+
+        // get index from masked vectors
+        ff1 #(
+            .LEN(NUM_REQ)
+        ) i_lower_ff1 (
+            .in_i        ( masked_lower  ),
+            .first_one_o ( lower_idx     ),
+            .no_ones_o   ( no_lower_ones )
+        );    
+
+        ff1 #(
+            .LEN(NUM_REQ)
+        ) i_upper_ff1 (
+            .in_i        ( masked_upper  ),
+            .first_one_o ( upper_idx     ),
+            .no_ones_o   (               )
+        );    
+
+        // wrap around
+        assign next_idx   = (no_lower_ones) ? upper_idx : lower_idx;
+        assign arb_sel_d  = (next_idx < NUM_REQ) ? next_idx : NUM_REQ-1;
+        
+    end
+endgenerate  
+
+genvar k;
+generate
+    for (k=0; (k < NUM_REQ) && NUM_REQ > 2; k++) begin
+        assign mask_lut[k]     = 2**(k+1)-1;
+        assign masked_lower[k] = (~ mask[k]) & req_i[k];
+        assign masked_upper[k] = mask[k]     & req_i[k];
+        assign ack_o[k]        = ((arb_sel_d == k) & vld_o ) ? 1'b1 : 1'b0;
+    end
+endgenerate
+
+// regs
+always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if(~rst_ni) begin
+        arb_sel_q <= 0;
+    end else begin
+        if (flush_i) begin
+            arb_sel_q <= 0;
+        end else if (vld_o) begin
+            arb_sel_q <= arb_sel_d;
+        end
+    end
+end
+
+
+`ifndef SYNTHESIS
+`ifndef VERILATOR
+    // check parameterization, enable and hot1 property of acks
+    // todo: check RR fairness with sequence assertion
+    initial begin
+        assert (NUM_REQ>=2) else $fatal ("minimum input width of req vecor is 2");
+    end
+    ack_implies_vld: assert property (@(posedge clk_i) disable iff (~rst_ni) |ack_o |-> vld_o)              else $fatal ("an asserted ack signal implies that vld_o must be asserted, too");
+    vld_implies_ack: assert property (@(posedge clk_i) disable iff (~rst_ni) vld_o  |-> |ack_o)             else $fatal ("an asserted vld_o signal implies that one ack_o must be asserted, too");
+    en_vld_check:    assert property (@(posedge clk_i) disable iff (~rst_ni) !en_i  |-> !vld_o)             else $fatal ("vld must not be asserted when arbiter is disabled");
+    en_ack_check:    assert property (@(posedge clk_i) disable iff (~rst_ni) !en_i  |-> !ack_o)             else $fatal ("ack_o must not be asserted when arbiter is disabled");
+    ack_idx_check:   assert property (@(posedge clk_i) disable iff (~rst_ni) vld_o |-> ack_o[idx_o])        else $fatal ("index / ack_o do not match");
+    hot1_check:      assert property (@(posedge clk_i) disable iff (~rst_ni) ((~(1<<idx_o)) & ack_o) == 0 ) else $fatal ("only one ack_o can be asserted at a time (i.e. ack_o must be hot1)");
+`endif
+`endif
+
+
+endmodule // rrarbiter
+
+
+

--- a/src/std_cache_subsystem.sv
+++ b/src/std_cache_subsystem.sv
@@ -1,0 +1,109 @@
+// Copyright (c) 2018 ETH Zurich, University of Bologna
+// All rights reserved.
+//
+// This code is under development and not yet released to the public.
+// Until it is released, the code is under the copyright of ETH Zurich and
+// the University of Bologna, and may contain confidential and/or unpublished
+// work. Any reuse/redistribution is strictly forbidden without written
+// permission from ETH Zurich.
+//
+// Bug fixes and contributions will eventually be released under the
+// SolderPad open hardware license in the context of the PULP platform
+// (http://www.pulp-platform.org), under the copyright of ETH Zurich and the
+// University of Bologna.
+//
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
+// Description: Standard Ariane cache subsystem with instruction cache and 
+//              write-back data cache.
+
+import ariane_pkg::*;
+import std_cache_pkg::*;
+
+module std_cache_subsystem #(
+   parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000,
+   parameter int unsigned AXI_ID_WIDTH     = 10,
+   parameter int unsigned AXI_USER_WIDTH   = 1
+)  (   
+   input logic                            clk_i,
+   input logic                            rst_ni,
+          
+   // Icache
+   //input  logic               flush_icache_i,     // instruction fence in
+    
+
+
+   // Dcache
+   // Cache management
+   input  logic                           dcache_enable_i,    // from CSR
+   input  logic                           dcache_flush_i,     // high until acknowledged
+   output logic                           dcache_flush_ack_o, // send a single cycle acknowledge signal when the cache is flushed
+   output logic                           dcache_miss_o,      // we missed on a ld/st
+   // Data cache refill port
+   AXI_BUS.Master                         dcache_data_if,
+   AXI_BUS.Master                         dcache_bypass_if,
+   // AMO interface
+   input  logic                           dcache_amo_commit_i, // commit atomic memory operation
+   output logic                           dcache_amo_valid_o,  // we have a valid AMO result
+   output logic [63:0]                    dcache_amo_result_o, // result of atomic memory operation
+   input  logic                           dcache_amo_flush_i,  // forget about AMO
+   // Request ports
+   input  dcache_req_i_t   [2:0]          dcache_req_ports_i,  
+   output dcache_req_o_t   [2:0]          dcache_req_ports_o
+);
+
+
+/*   icache #(
+      .SET_ASSOCIATIVITY ( 4                    ),
+      .CACHE_LINE_WIDTH  ( 128                  ),
+      .FETCH_WIDTH       ( FETCH_WIDTH          )
+   ) i_icache (
+      .flush_i          ( flush_icache_i        ),
+      .vaddr_i          ( fetch_vaddr           ), // 1st cycle
+      .is_speculative_i ( fetch_is_speculative  ), // 1st cycle
+      .data_o           ( icache_data_d         ),
+      .req_i            ( icache_req            ),
+      .kill_s1_i        ( kill_s1               ),
+      .kill_s2_i        ( kill_s2               ),
+      .ready_o          ( icache_ready          ),
+      .valid_o          ( icache_valid_d        ),
+      .ex_o             ( icache_ex_d           ),
+      .is_speculative_o ( icache_speculative_d  ),
+      .vaddr_o          ( icache_vaddr_d        ),
+      .axi              ( axi                   ),
+      .miss_o           ( l1_icache_miss_o      ),
+      .*
+   );
+*/
+
+
+   // decreasing priority
+   // Port 0: PTW
+   // Port 1: Load Unit
+   // Port 2: Store Unit
+   nbdcache #(
+      .CACHE_START_ADDR ( CACHE_START_ADDR ),
+      .AXI_ID_WIDTH     ( AXI_ID_WIDTH     ),
+      .AXI_USER_WIDTH   ( AXI_USER_WIDTH   )
+   ) i_nbdcache (
+      .clk_i              ( clk_i                  ),
+      .rst_ni             ( rst_ni                 ),
+      .enable_i           ( dcache_enable_i        ),
+      .flush_i            ( dcache_flush_i         ),
+      .flush_ack_o        ( dcache_flush_ack_o     ),
+      .miss_o             ( dcache_miss_o          ),
+      .data_if            ( dcache_data_if         ),
+      .bypass_if          ( dcache_bypass_if       ),
+      .amo_commit_i       ( dcache_amo_commit_i    ),
+      .amo_valid_o        ( dcache_amo_valid_o     ),
+      .amo_result_o       ( dcache_amo_result_o    ),
+      .amo_flush_i        ( dcache_amo_flush_i     ),
+      .req_ports_i        ( dcache_req_ports_i     ),
+      .req_ports_o        ( dcache_req_ports_o     )
+   );
+
+
+
+
+endmodule // std_cache_subsystem

--- a/src/std_cache_subsystem.sv
+++ b/src/std_cache_subsystem.sv
@@ -22,58 +22,58 @@ import ariane_pkg::*;
 import std_cache_pkg::*;
 
 module std_cache_subsystem #(
-   parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000,
-   parameter int unsigned AXI_ID_WIDTH     = 10,
-   parameter int unsigned AXI_USER_WIDTH   = 1
+   parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000
 )  (   
    input logic                            clk_i,
    input logic                            rst_ni,
           
-   // Icache
-   //input  logic               flush_icache_i,     // instruction fence in
-
-   // Dcache
+   // I$
+   input  logic                           icache_flush_i,         // flush the icache, flush and kill have to be asserted together
+   input  logic                           icache_fetch_enable_i,  // the core should fetch instructions
+   output logic                           icache_miss_o,          // to performance counter
+      
+   // address translation requests      
+   input  icache_areq_i_t                 icache_areq_i,          // to/from frontend 
+   output icache_areq_o_t                 icache_areq_o,           
+   // data requests      
+   input  icache_dreq_i_t                 icache_dreq_i,          // to/from frontend 
+   output icache_dreq_o_t                 icache_dreq_o, 
+    
+   // D$
    // Cache management
-   input  logic                           dcache_enable_i,    // from CSR
-   input  logic                           dcache_flush_i,     // high until acknowledged
-   output logic                           dcache_flush_ack_o, // send a single cycle acknowledge signal when the cache is flushed
-   output logic                           dcache_miss_o,      // we missed on a ld/st
-   // Data cache refill port
-   AXI_BUS.Master                         dcache_data_if,
-   AXI_BUS.Master                         dcache_bypass_if,
-   // AMO interface
-   input  logic                           dcache_amo_commit_i, // commit atomic memory operation
-   output logic                           dcache_amo_valid_o,  // we have a valid AMO result
-   output logic [63:0]                    dcache_amo_result_o, // result of atomic memory operation
-   input  logic                           dcache_amo_flush_i,  // forget about AMO
+   input  logic                           dcache_enable_i,        // from CSR
+   input  logic                           dcache_flush_i,         // high until acknowledged
+   output logic                           dcache_flush_ack_o,     // send a single cycle acknowledge signal when the cache is flushed
+   output logic                           dcache_miss_o,          // we missed on a ld/st
+   // AMO interface   
+   input  logic                           dcache_amo_commit_i,    // commit atomic memory operation
+   output logic                           dcache_amo_valid_o,     // we have a valid AMO result
+   output logic [63:0]                    dcache_amo_result_o,    // result of atomic memory operation
+   input  logic                           dcache_amo_flush_i,     // forget about AMO
    // Request ports
-   input  dcache_req_i_t   [2:0]          dcache_req_ports_i,  
-   output dcache_req_o_t   [2:0]          dcache_req_ports_o
+   input  dcache_req_i_t   [2:0]          dcache_req_ports_i,     // to/from LSU
+   output dcache_req_o_t   [2:0]          dcache_req_ports_o,     // to/from LSU
+
+   // memory side
+   AXI_BUS.Master                         icache_data_if,          // I$ refill port
+   AXI_BUS.Master                         dcache_data_if,          // D$ refill port
+   AXI_BUS.Master                         dcache_bypass_if         // bypass axi port (disabled D$ or uncacheable access)
 );
 
 
-/*   icache #(
-      .SET_ASSOCIATIVITY ( 4                    ),
-      .CACHE_LINE_WIDTH  ( 128                  ),
-      .FETCH_WIDTH       ( FETCH_WIDTH          )
+   icache #(
    ) i_icache (
-      .flush_i          ( flush_icache_i        ),
-      .vaddr_i          ( fetch_vaddr           ), // 1st cycle
-      .is_speculative_i ( fetch_is_speculative  ), // 1st cycle
-      .data_o           ( icache_data_d         ),
-      .req_i            ( icache_req            ),
-      .kill_s1_i        ( kill_s1               ),
-      .kill_s2_i        ( kill_s2               ),
-      .ready_o          ( icache_ready          ),
-      .valid_o          ( icache_valid_d        ),
-      .ex_o             ( icache_ex_d           ),
-      .is_speculative_o ( icache_speculative_d  ),
-      .vaddr_o          ( icache_vaddr_d        ),
-      .axi              ( axi                   ),
-      .miss_o           ( l1_icache_miss_o      ),
-      .*
+      .clk_i             ( clk_i                 ),
+      .rst_ni            ( rst_ni                ),
+      .flush_i           ( icache_flush_i        ),
+      .fetch_enable_i    ( icache_fetch_enable_i ),
+      .miss_o            ( icache_miss_o         ),
+      .areq_i            ( icache_areq_i         ),
+      .areq_o            ( icache_areq_o         ),
+      .dreq_i            ( icache_dreq_i         ),
+      .dreq_o            ( icache_dreq_o         ),
+      .axi               ( icache_data_if        )
    );
-*/
 
 
    // decreasing priority
@@ -81,9 +81,7 @@ module std_cache_subsystem #(
    // Port 1: Load Unit
    // Port 2: Store Unit
    nbdcache #(
-      .CACHE_START_ADDR ( CACHE_START_ADDR ),
-      .AXI_ID_WIDTH     ( AXI_ID_WIDTH     ),
-      .AXI_USER_WIDTH   ( AXI_USER_WIDTH   )
+      .CACHE_START_ADDR ( CACHE_START_ADDR )
    ) i_nbdcache (
       .clk_i              ( clk_i                  ),
       .rst_ni             ( rst_ni                 ),
@@ -100,8 +98,6 @@ module std_cache_subsystem #(
       .req_ports_i        ( dcache_req_ports_i     ),
       .req_ports_o        ( dcache_req_ports_o     )
    );
-
-
 
 
 endmodule // std_cache_subsystem

--- a/src/std_cache_subsystem.sv
+++ b/src/std_cache_subsystem.sv
@@ -23,7 +23,7 @@ import std_cache_pkg::*;
 
 module std_cache_subsystem #(
    parameter logic [63:0] CACHE_START_ADDR = 64'h4000_0000
-)  (   
+)(   
    input logic                            clk_i,
    input logic                            rst_ni,
           

--- a/src/std_cache_subsystem.sv
+++ b/src/std_cache_subsystem.sv
@@ -31,8 +31,6 @@ module std_cache_subsystem #(
           
    // Icache
    //input  logic               flush_icache_i,     // instruction fence in
-    
-
 
    // Dcache
    // Cache management

--- a/src/store_unit.sv
+++ b/src/store_unit.sv
@@ -41,17 +41,8 @@ module store_unit (
     input  logic [11:0]              page_offset_i,
     output logic                     page_offset_matches_o,
     // D$ interface
-    output logic [11:0]              address_index_o,
-    output logic [43:0]              address_tag_o,
-    output logic [63:0]              data_wdata_o,
-    output logic                     data_req_o,
-    output logic                     data_we_o,
-    output logic [7:0]               data_be_o,
-    output logic [1:0]               data_size_o,
-    output logic                     kill_req_o,
-    output logic                     tag_valid_o,
-    input  logic                     data_gnt_i,
-    input  logic                     data_rvalid_i
+    input  dcache_req_o_t            req_port_i,
+    output dcache_req_i_t            req_port_o  
 );
     assign result_o = 64'b0;
 
@@ -206,6 +197,10 @@ module store_unit (
         .data_size_i           ( st_data_size_q         ),
         // store buffer out
         .ready_o               ( st_ready               ),
+        
+        .req_port_i            ( req_port_i             ),
+        .req_port_o            ( req_port_o             ),
+
         .*
     );
     // ---------------

--- a/src/util/cluster_clock_gating.sv
+++ b/src/util/cluster_clock_gating.sv
@@ -23,7 +23,7 @@ module cluster_clock_gating (
 `ifdef PULP_FPGA_EMUL
   // no clock gates in FPGA flow
   assign clk_o = clk_i;
-`elseif verilator
+`elsif verilator
   assign clk_o = clk_i;
 `else
   logic clk_en;

--- a/src_files.yml
+++ b/src_files.yml
@@ -4,7 +4,7 @@ ariane:
   ]
   files: [
     include/ariane_pkg.sv,
-    include/nbdcache_pkg.sv,
+    include/std_cache_pkg.sv,
     src/util/instruction_tracer_if.sv,
     src/util/instruction_tracer_pkg.sv,
     src/alu.sv,
@@ -36,6 +36,7 @@ ariane:
     src/mmu.sv,
     src/mult.sv,
     src/nbdcache.sv,
+    src/std_cache_subsystem.sv,
     src/pcgen_stage.sv,
     src/perf_counters.sv,
     src/ptw.sv,


### PR DESCRIPTION
the uvm-components submodule needs to be fixed to point to 6bb81367a35bde8952217685dba9457183bc63ea
in order to account for the interface changes (see separate pull request)


