### PR TITLE
Minimal set of changes to add vcsrun target

### DIFF
--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -595,9 +595,14 @@ module ariane #(
     // -------------------
     // Instruction Tracer
     // -------------------
-    `ifndef VCS
+    `ifdef VCS
+     `define MOCK_TRACER
+    `endif
+    `ifdef verilator
+     `define MOCK_TRACER
+    `endif
     `ifndef SYNTHESIS
-    `ifndef verilator
+    `ifndef MOCK_TRACER
     instruction_tracer_if tracer_if (clk_i);
     // assign instruction tracer interface
     // control signals
@@ -699,7 +704,6 @@ module ariane #(
     final begin
         $fclose(f);
     end
-    `endif
     `endif
     `endif
 endmodule // ariane

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -13,9 +13,11 @@
 // Description: Ariane Top-level module
 
 import ariane_pkg::*;
+`ifndef VCS
 `ifndef verilator
 `ifndef SYNTHESIS
 import instruction_tracer_pkg::*;
+`endif
 `endif
 `endif
 
@@ -593,6 +595,7 @@ module ariane #(
     // -------------------
     // Instruction Tracer
     // -------------------
+    `ifndef VCS
     `ifndef SYNTHESIS
     `ifndef verilator
     instruction_tracer_if tracer_if (clk_i);
@@ -632,11 +635,7 @@ module ariane #(
     assign tracer_if.priv_lvl          = priv_lvl;
     assign tracer_if.debug_mode        = debug_mode;
     instr_tracer instr_tracer_i (tracer_if, cluster_id_i, core_id_i);
-    `endif
-    `endif
 
-    `ifndef SYNTHESIS
-    `ifndef verilator
     program instr_tracer (
             instruction_tracer_if tracer_if,
             input logic [5:0] cluster_id_i,
@@ -700,6 +699,7 @@ module ariane #(
     final begin
         $fclose(f);
     end
+    `endif
     `endif
     `endif
 endmodule // ariane

--- a/src/cache_subsystem/std_nbdcache.sv
+++ b/src/cache_subsystem/std_nbdcache.sv
@@ -332,11 +332,13 @@ module tag_cmp #(
                 break;
         end
 
+        `ifndef VCS
         `ifndef SYNTHESIS
         `ifndef VERILATOR
         // assert that cache only hits on one way
         assert property (
           @(posedge clk_i) $onehot0(hit_way_o)) else begin $error("Hit should be one-hot encoded"); $stop(); end
+        `endif
         `endif
         `endif
     end

--- a/tb/ariane_tb.sv
+++ b/tb/ariane_tb.sv
@@ -15,9 +15,11 @@
 
 
 import ariane_pkg::*;
+`ifndef VCS
 import uvm_pkg::*;
 
 `include "uvm_macros.svh"
+`endif
 
 module ariane_tb;
 
@@ -41,6 +43,9 @@ module ariane_tb;
 
     // Clock process
     initial begin
+`ifdef VCS
+        $vcdpluson;
+`endif       
         clk_i = 1'b0;
         rst_ni = 1'b0;
         repeat(8)
@@ -57,6 +62,7 @@ module ariane_tb;
         end
     end
 
+`ifndef VCS
     initial begin
         forever begin
 
@@ -71,5 +77,6 @@ module ariane_tb;
             $finish();
         end
     end
+`endif
 
 endmodule

--- a/tb/common/SimDTM.sv
+++ b/tb/common/SimDTM.sv
@@ -1,6 +1,7 @@
 // See LICENSE.SiFive for license details.
 //VCS coverage exclude_file
 
+`ifndef VCS
 import "DPI-C" function int debug_tick
 (
   output bit     debug_req_valid,
@@ -14,7 +15,8 @@ import "DPI-C" function int debug_tick
   input  int        debug_resp_bits_resp,
   input  int        debug_resp_bits_data
 );
-
+`endif //  `ifndef VCS
+   
 module SimDTM(
   input clk,
   input reset,
@@ -33,6 +35,11 @@ module SimDTM(
   output [31:0] exit
 );
 
+`ifdef VCS
+   // DTM is disabled in VCS for now ...
+   assign { debug_req_valid, debug_req_bits_addr, debug_req_bits_op, debug_req_bits_data, debug_resp_ready, exit } = '0;
+`else
+   
   bit r_reset;
 
   wire #0.1 __debug_req_ready = debug_req_ready;
@@ -78,4 +85,7 @@ module SimDTM(
       );
     end
   end
+
+`endif // !`ifdef VCS
+   
 endmodule

--- a/tb/dpi/SimJTAG.cc
+++ b/tb/dpi/SimJTAG.cc
@@ -15,7 +15,7 @@ extern "C" int jtag_tick
 {
   if (!jtag) {
     // TODO: Pass in real port number
-    jtag = new remote_bitbang_t(0);
+    jtag = new remote_bitbang_t(2222);
   }
 
   jtag->tick(jtag_TCK, jtag_TMS, jtag_TDI, jtag_TRSTn, jtag_TDO);


### PR DESCRIPTION
Minimal set of changes to add vcsrun target (using Synopsys vcs), whilst still allowing verilator to work (needs review for Questa compatibility)

Some simulation features are difficult to make compatible with vcs, so conditionally disabled for now. Current version comes up in openocd and recognises debug behaviour correctly.
