### PR TITLE
DM: Fix misaligned progbufsize and reg checks

### DIFF
--- a/src/debug/dm_mem.sv
+++ b/src/debug/dm_mem.sv
@@ -289,17 +289,17 @@ module dm_mem #(
             // --------------------
             dm::AccessRegister: begin
                 if (ac_ar.aarsize < 4 && ac_ar.transfer && ac_ar.write) begin
+                    // this range is reserved
+                    if (ac_ar.regno[15:14] != '0) begin
+                        abstract_cmd[0][31:0] = riscv::illegal();
                     // GPR/FPR access
-                    if (ac_ar.regno[12]) begin
+                    end else if (ac_ar.regno[12]) begin
                         // determine whether we want to access the floating point register or not
                         if (ac_ar.regno[5]) begin
                             abstract_cmd[0][31:0] = riscv::float_load(ac_ar.aarsize, ac_ar.regno[4:0], 0, dm::DataAddr);
                         end else begin
                             abstract_cmd[0][31:0] = riscv::load(ac_ar.aarsize, ac_ar.regno[4:0], 0, dm::DataAddr);
                         end
-                    // this range is reserved
-                    end else if (ac_ar.regno[15:14] != '0) begin
-                        abstract_cmd[0][31:0] = riscv::illegal();
                     // CSR access
                     end else begin
                         // data register to CSR
@@ -313,16 +313,17 @@ module dm_mem #(
                         abstract_cmd[1][63:32] = riscv::csrr(riscv::CSR_DSCRATCH0, 8);
                     end
                 end else if (ac_ar.aarsize < 4 && ac_ar.transfer && !ac_ar.write) begin
+                    // this range is reserved
+                    if (ac_ar.regno[15:14] != '0) begin
+                        abstract_cmd[0][31:0] = riscv::illegal();
                     // GPR/FPR access
-                    if (ac_ar.regno[12]) begin
+                    end else if (ac_ar.regno[12]) begin
                         // determine whether we want to access the floating point register or not
                         if (ac_ar.regno[5]) begin
                             abstract_cmd[0][31:0] = riscv::float_store(ac_ar.aarsize, ac_ar.regno[4:0], 0, dm::DataAddr);
                         end else begin
                             abstract_cmd[0][31:0] = riscv::store(ac_ar.aarsize, ac_ar.regno[4:0], 0, dm::DataAddr);
                         end
-                    end else if (ac_ar.regno[15:14] != '0) begin
-                        abstract_cmd[0][31:0] = riscv::illegal();
                     // CSR access
                     end else begin
                         // CSR register to data

--- a/src/debug/dm_pkg.sv
+++ b/src/debug/dm_pkg.sv
@@ -141,7 +141,7 @@ package dm;
     typedef struct packed {
         logic [31:29] zero3;
         logic [28:24] progbufsize;
-        logic [23:12] zero2;
+        logic [23:13] zero2;
         logic         busy;
         logic         zero1;
         cmderr_t      cmderr;


### PR DESCRIPTION
The struct for `abstract_cs` was accidentally one bit too large.
This can lead to wrong conversions from DMI data when re-casted.

Furthermore register address checks during an abstract command were
potentially too loose when CSR would be accessed.