### PR TITLE
Fix library path also for Modelsim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ $(dpi-library)/%.o: tb/dpi/%.cc $(dpi_hdr)
 $(dpi-library)/ariane_dpi.so: $(dpi)
 	mkdir -p $(dpi-library)
 	# Compile C-code and generate .so file
-	$(CXX) -shared -m64 -o $(dpi-library)/ariane_dpi.so $? -lfesvr
+	$(CXX) -shared -m64 -o $(dpi-library)/ariane_dpi.so $? -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -lfesvr
 
 # single test runs on Questa can be started by calling make <testname>, e.g. make towers.riscv
 # the test names are defined in ci/riscv-asm-tests.list, and in ci/riscv-benchmarks.list


### PR DESCRIPTION
This makes the Makefile a bit more useable and doesn't require to set an explicit `LD_LIBRARY_PATH`. I've done the same for Verilator in another PR but forgot to add it to the Modelsim target.