### PR TITLE
Correct mdio_oe naming, streamline to allow 1GHz capability

### DIFF
--- a/fpga/constraints/genesys-2.xdc
+++ b/fpga/constraints/genesys-2.xdc
@@ -68,30 +68,11 @@ set_property -dict {PACKAGE_PIN AG12 IOSTANDARD LVCMOS15} [get_ports { eth_mdio 
 # set_property -dict {PACKAGE_PIN AK16  IOSTANDARD LVCMOS18} [get_ports { eth_int_b }]; #IO_L1P_T0_32 Sch=eth_intb
 
 #############################################
-# Ethernet Constraints for 100 Mb/s
+# Ethernet Constraints for 1Gb/s
 #############################################
-# Copied from OpenPiton Project
-# hint from here: https://forums.xilinx.com/t5/Timing-Analysis/XDC-constraints-Source-Synchronous-ADC-DDR/td-p/292807
-create_clock -period 40.000 -name eth_rxck_virt
-# set_clock_groups -asynchronous -group [get_clocks chipset_clk_clk_mmcm] -group [get_clocks eth_rxck]
-# conservatively assuming +/- 2ns skew of rxd/rxctl
-create_clock -period 40.000 -name eth_rxck -waveform {2.000 22.000} [get_ports eth_rxck]
-
-
-# Input constraints
-set_input_delay -clock [get_clocks eth_rxck_virt] -min -add_delay 0.000 [get_ports {eth_rxd[*]}]
-set_input_delay -clock [get_clocks eth_rxck_virt] -max -add_delay 4.000 [get_ports {eth_rxd[*]}]
-set_input_delay -clock [get_clocks eth_rxck_virt] -clock_fall -min -add_delay 0.000 [get_ports eth_rxctl]
-set_input_delay -clock [get_clocks eth_rxck_virt] -clock_fall -max -add_delay 4.000 [get_ports eth_rxctl]
-set_input_delay -clock [get_clocks eth_rxck_virt] -min -add_delay 0.000 [get_ports eth_rxctl]
-set_input_delay -clock [get_clocks eth_rxck_virt] -max -add_delay 4.000 [get_ports eth_rxctl]
-
-# Output Constraints
-create_generated_clock -name eth_txck_gen -source [get_pins i_ariane_peripherals/gen_ethernet.i_rgmii_to_mii_conv_xilinx/net_phy_txc_oddr/C] -multiply_by 1 [get_ports eth_txck]
-
-# Constraint RGMII interface
-set_output_delay -clock eth_txck_gen 2.000 [get_ports eth_txctl]
-set_output_delay -clock eth_txck_gen 2.000 [get_ports {eth_txd[*]}]
+# Modified for 125MHz receive clock
+create_clock -period 8.000 -name eth_rxck [get_ports eth_rxck]
+set_clock_groups -asynchronous -group [get_clocks eth_rxclk -include_generated_clocks]
 
 ## SD Card
 set_property -dict {PACKAGE_PIN R28 IOSTANDARD LVCMOS33} [get_ports spi_clk_o]

--- a/fpga/src/ariane_peripherals_xilinx.sv
+++ b/fpga/src/ariane_peripherals_xilinx.sv
@@ -490,7 +490,7 @@ module ariane_peripherals #(
     if (InclEthernet) begin : gen_ethernet
 
 logic                    clk_200_int, clk_rgmii, clk_rgmii_quad; 
-logic                    eth_en, eth_we, eth_int_n, eth_pme_n, eth_mdio_i, eth_mdio_o, eth_mdio_oen;
+logic                    eth_en, eth_we, eth_int_n, eth_pme_n, eth_mdio_i, eth_mdio_o, eth_mdio_oe;
 logic [AxiAddrWidth-1:0] eth_addr;
 logic [AxiDataWidth-1:0] eth_wrdata, eth_rdata;
 logic [AxiDataWidth/8-1:0] eth_be;
@@ -541,7 +541,7 @@ framing_top eth_rgmii
    .phy_mdc(eth_mdc),
    .phy_mdio_i(eth_mdio_i),
    .phy_mdio_o(eth_mdio_o),
-   .phy_mdio_oen(eth_mdio_oen),
+   .phy_mdio_oe(eth_mdio_oe),
    .eth_irq(irq_sources[2])
 );
 
@@ -554,7 +554,7 @@ framing_top eth_rgmii
       .O(eth_mdio_i),     // Buffer output
       .IO(eth_mdio),   // Buffer inout port (connect directly to top-level port)
       .I(eth_mdio_o),     // Buffer input
-      .T(~eth_mdio_oen)      // 3-state enable input, high=input, low=output
+      .T(~eth_mdio_oe)      // 3-state enable input, high=input, low=output
    );
 
     end else begin


### PR DESCRIPTION
The correction to the 1000BaseT mode is ready for review and merge. The one remaining issue is why we do not see interrupts. A very similar arrangement in LowRISC with Rocket does show the expected interrupts. I am seeing a slow down with all the new kernel options being enabled. This needs reviewing as well to see if they are all necessary.