### PR TITLE
Fix the multi-thread library dependency error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,30 +345,30 @@ check-benchmarks:
 	ci/check-tests.sh tmp/riscv-benchmarks- $(shell wc -l $(riscv-benchmarks-list) | awk -F " " '{ print $1 }')
 
 # verilator-specific
-verilate_command := $(verilator)                                                                       \
-                    $(filter-out %.vhd, $(ariane_pkg))                                                 \
-                    $(filter-out src/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                         \
-                    +define+$(defines)                                                                 \
-                    src/util/sram.sv                                                                   \
-                    +incdir+src/axi_node                                                               \
-                    $(if $(verilator_threads), --threads $(verilator_threads))                         \
-                    --unroll-count 256                                                                 \
-                    -Werror-PINMISSING                                                                 \
-                    -Werror-IMPLICIT                                                                   \
-                    -Wno-fatal                                                                         \
-                    -Wno-PINCONNECTEMPTY                                                               \
-                    -Wno-ASSIGNDLY                                                                     \
-                    -Wno-DECLFILENAME                                                                  \
-                    -Wno-UNUSED                                                                        \
-                    -Wno-UNOPTFLAT                                                                     \
-                    -Wno-style                                                                         \
-                    $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                            \
-                    $(if $(DEBUG),--trace --trace-structs,)                                            \
-                    -LDFLAGS "-L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -lfesvr$(if $(PROFILE), -g -pg,)" \
-                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,)" -Wall --cc  --vpi                     \
-                    $(list_incdir) --top-module ariane_testharness                                     \
-                    --Mdir $(ver-library) -O3                                                          \
-                    --exe tb/ariane_tb.cpp tb/dpi/SimDTM.cc tb/dpi/SimJTAG.cc                          \
+verilate_command := $(verilator)                                                                                 \
+                    $(filter-out %.vhd, $(ariane_pkg))                                                           \
+                    $(filter-out src/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                   \
+                    +define+$(defines)                                                                           \
+                    src/util/sram.sv                                                                             \
+                    +incdir+src/axi_node                                                                         \
+                    $(if $(verilator_threads), --threads $(verilator_threads))                                   \
+                    --unroll-count 256                                                                           \
+                    -Werror-PINMISSING                                                                           \
+                    -Werror-IMPLICIT                                                                             \
+                    -Wno-fatal                                                                                   \
+                    -Wno-PINCONNECTEMPTY                                                                         \
+                    -Wno-ASSIGNDLY                                                                               \
+                    -Wno-DECLFILENAME                                                                            \
+                    -Wno-UNUSED                                                                                  \
+                    -Wno-UNOPTFLAT                                                                               \
+                    -Wno-style                                                                                   \
+                    $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
+                    $(if $(DEBUG),--trace --trace-structs,)                                                      \
+                    -LDFLAGS "-L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -lfesvr$(if $(PROFILE), -g -pg,) -lpthread" \
+                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,)" -Wall --cc  --vpi                               \
+                    $(list_incdir) --top-module ariane_testharness                                               \
+                    --Mdir $(ver-library) -O3                                                                    \
+                    --exe tb/ariane_tb.cpp tb/dpi/SimDTM.cc tb/dpi/SimJTAG.cc                                    \
 					tb/dpi/remote_bitbang.cc tb/dpi/msim_helper.cc
 
 # User Verilator, at some point in the future this will be auto-generated


### PR DESCRIPTION
It gives an error of undefined reference to multi-thread library when compiling Ariane with verilator. Add a library flag to solve this problem.