### PR TITLE
 fp_dirty: Dirty on fp register write

### DIFF
--- a/src/commit_stage.sv
+++ b/src/commit_stage.sv
@@ -77,7 +77,7 @@ module commit_stage #(
     always_comb begin : dirty_fp_state
       dirty_fp_state_o = 1'b0;
       for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
-        dirty_fp_state_o |= commit_ack_o[i] & commit_instr_i[i].fu inside {FPU, FPU_VEC};
+        dirty_fp_state_o |= commit_ack_o[i] & (commit_instr_i[i].fu inside {FPU, FPU_VEC} || is_rd_fpr(commit_instr_i[0].op));
       end
     end
 

--- a/src/util/instr_tracer.sv
+++ b/src/util/instr_tracer.sv
@@ -184,6 +184,7 @@ module instr_tracer (
     bp              = {};
   endfunction
 
+  // pragma translate_off
   function void printInstr(ariane_pkg::scoreboard_entry_t sbe, logic [31:0] instr, logic [63:0] result, logic [63:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
     automatic instr_trace_item iti = new ($time, clk_ticks, sbe, instr, gp_reg_file, fp_reg_file, result, paddr, priv_lvl, debug_mode, bp);
     // print instruction to console
@@ -217,5 +218,6 @@ module instr_tracer (
   final begin
     close();
   end
+  // pragma translate_on
 
 endmodule : instr_tracer


### PR DESCRIPTION
That should fix loads to floating point regs not dirtying the FP state (should fix #233). 

@jrrk I'd greatly appreciate if you could test the fix with your setup.