### PR TITLE
Add pragma around non-synthesisable code

### DIFF
--- a/src/util/instr_tracer.sv
+++ b/src/util/instr_tracer.sv
@@ -184,6 +184,7 @@ module instr_tracer (
     bp              = {};
   endfunction
 
+  // pragma translate_off
   function void printInstr(ariane_pkg::scoreboard_entry_t sbe, logic [31:0] instr, logic [63:0] result, logic [63:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
     automatic instr_trace_item iti = new ($time, clk_ticks, sbe, instr, gp_reg_file, fp_reg_file, result, paddr, priv_lvl, debug_mode, bp);
     // print instruction to console
@@ -217,5 +218,6 @@ module instr_tracer (
   final begin
     close();
   end
+  // pragma translate_on
 
 endmodule : instr_tracer


### PR DESCRIPTION
Since the function spikeCommitLog in riscv_pkg.sv has // pragma translate_off/on around it, so must the corresponding code printInstr in instr_tracer.sv, in order to get through Vivado.
