### PR TITLE
Remove interface name aliasing to keep VCS happy

### DIFF
--- a/fpga/src/ariane_peripherals_xilinx.sv
+++ b/fpga/src/ariane_peripherals_xilinx.sv
@@ -23,17 +23,17 @@ module ariane_peripherals #(
     input  logic       clk_i           , // Clock
     input  logic       clk_200MHz_i    ,
     input  logic       rst_ni          , // Asynchronous reset active low
-    AXI_BUS.in         plic            ,
-    AXI_BUS.in         uart            ,
-    AXI_BUS.in         spi             ,
-    AXI_BUS.in         gpio            ,
-    input  logic       eth_clk_i       ,
-    AXI_BUS.in         ethernet        ,
+    AXI_BUS.Slave      plic            ,
+    AXI_BUS.Slave      uart            ,
+    AXI_BUS.Slave      spi             ,
+    AXI_BUS.Slave      gpio            ,
+    AXI_BUS.Slave      ethernet        ,
     output logic [1:0] irq_o           ,
     // UART
     input  logic       rx_i            ,
     output logic       tx_o            ,
     // Ethernet
+    input  logic       eth_clk_i       ,
     input  wire        eth_rxck        ,
     input  wire        eth_rxctl       ,
     input  wire [3:0]  eth_rxd         ,

--- a/fpga/src/ariane_xilinx.sv
+++ b/fpga/src/ariane_xilinx.sv
@@ -16,9 +16,9 @@ module ariane_xilinx (
   input  logic         sys_clk_p   ,
   input  logic         sys_clk_n   ,
   input  logic         cpu_resetn  ,
-  inout  logic [31:0]  ddr3_dq     ,
-  inout  logic [ 3:0]  ddr3_dqs_n  ,
-  inout  logic [ 3:0]  ddr3_dqs_p  ,
+  inout  wire  [31:0]  ddr3_dq     ,
+  inout  wire  [ 3:0]  ddr3_dqs_n  ,
+  inout  wire  [ 3:0]  ddr3_dqs_p  ,
   output logic [14:0]  ddr3_addr   ,
   output logic [ 2:0]  ddr3_ba     ,
   output logic         ddr3_ras_n  ,
@@ -79,7 +79,7 @@ module ariane_xilinx (
   input  logic        tms         ,
   input  logic        trst_n      ,
   input  logic        tdi         ,
-  output logic        tdo         ,
+  output wire         tdo         ,
   input  logic        rx          ,
   output logic        tx
 );

--- a/include/axi_intf.sv
+++ b/include/axi_intf.sv
@@ -99,24 +99,6 @@ interface AXI_BUS #(
     output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
   );
 
-  /// The interface as an output (issuing requests, initiator, master).
-  modport out (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_atop, aw_region, aw_user, aw_valid, input aw_ready,
-    output w_data, w_strb, w_last, w_user, w_valid, input w_ready,
-    input b_id, b_resp, b_user, b_valid, output b_ready,
-    output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, input ar_ready,
-    input r_id, r_data, r_resp, r_last, r_user, r_valid, output r_ready
-  );
-
-  /// The interface as an input (accepting requests, target, slave).
-  modport in (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_atop, aw_region, aw_user, aw_valid, output aw_ready,
-    input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
-    output b_id, b_resp, b_user, b_valid, input b_ready,
-    input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, output ar_ready,
-    output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
-  );
-
 endinterface
 
 

--- a/src/util/axi_master_connect.sv
+++ b/src/util/axi_master_connect.sv
@@ -14,7 +14,7 @@
 module axi_master_connect (
     input  ariane_axi::req_t    axi_req_i,
     output ariane_axi::resp_t   axi_resp_o,
-    AXI_BUS.out master
+    AXI_BUS.Master master
 );
 
     assign master.aw_id         = axi_req_i.aw.id;

--- a/src/util/axi_master_connect_rev.sv
+++ b/src/util/axi_master_connect_rev.sv
@@ -14,7 +14,7 @@
 module axi_master_connect_rev (
     output ariane_axi::req_t    axi_req_o,
     input  ariane_axi::resp_t   axi_resp_i,
-    AXI_BUS.in master
+    AXI_BUS.Slave master
 );
 
     assign  axi_req_o.aw.atop    = '0; // not supported at the moment

--- a/src/util/axi_slave_connect.sv
+++ b/src/util/axi_slave_connect.sv
@@ -14,7 +14,7 @@
 module axi_slave_connect (
     output ariane_axi::req_t    axi_req_o,
     input  ariane_axi::resp_t   axi_resp_i,
-    AXI_BUS.in slave
+    AXI_BUS.Slave slave
 );
 
     assign  axi_req_o.aw.id      = slave.aw_id;

--- a/src/util/axi_slave_connect_rev.sv
+++ b/src/util/axi_slave_connect_rev.sv
@@ -14,7 +14,7 @@
 module axi_slave_connect_rev (
     input  ariane_axi::req_t    axi_req_i,
     output ariane_axi::resp_t   axi_resp_o,
-    AXI_BUS.out slave
+    AXI_BUS.Master slave
 );
 
     assign slave.aw_id         = axi_req_i.aw.id;

--- a/tb/ariane_peripherals.sv
+++ b/tb/ariane_peripherals.sv
@@ -21,10 +21,10 @@ module ariane_peripherals #(
 ) (
     input  logic       clk_i           , // Clock
     input  logic       rst_ni          , // Asynchronous reset active low
-    AXI_BUS.in         plic            ,
-    AXI_BUS.in         uart            ,
-    AXI_BUS.in         spi             ,
-    AXI_BUS.in         ethernet        ,
+    AXI_BUS.Slave      plic            ,
+    AXI_BUS.Slave      uart            ,
+    AXI_BUS.Slave      spi             ,
+    AXI_BUS.Slave      ethernet        ,
     output logic [1:0] irq_o           ,
     // UART
     input  logic       rx_i            ,


### PR DESCRIPTION
At the moment in an alias for Slave and out an alias for Master. This causes VCS to complain and refuse to compile when the names are mixed. This PR remove the in and out aliases. Requires [this PR](https://github.com/pulp-platform/axi/pull/9)