### PR TITLE
Enable exp_backoff for LR/SC 

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -188,6 +188,7 @@ sources:
     - src/common_cells/src/lfsr_16bit.sv
     - src/common_cells/src/counter.sv
     - src/common_cells/src/shift_reg.sv
+    - src/common_cells/src/exp_backoff.sv
     - src/tech_cells_generic/src/cluster_clock_inverter.sv
     - src/tech_cells_generic/src/pulp_clock_mux2.sv
     - target: test

--- a/Flist.ariane
+++ b/Flist.ariane
@@ -31,6 +31,7 @@ src/common_cells/src/cdc_2phase.sv
 src/common_cells/src/shift_reg.sv
 src/common_cells/src/unread.sv
 src/common_cells/src/popcount.sv
+src/common_cells/src/exp_backoff.sv
 src/register_interface/src/apb_to_reg.sv
 src/register_interface/src/reg_intf_pkg.sv
 src/register_interface/src/reg_intf.sv

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         src/common_cells/src/rstgen.sv                                         \
         src/common_cells/src/stream_mux.sv                                     \
         src/common_cells/src/stream_demux.sv                                   \
+	src/common_cells/src/exp_backoff.sv                                    \
         src/util/axi_master_connect.sv                                         \
         src/util/axi_slave_connect.sv                                          \
         src/util/axi_master_connect_rev.sv                                     \

--- a/src/cache_subsystem/wt_dcache_missunit.sv
+++ b/src/cache_subsystem/wt_dcache_missunit.sv
@@ -236,17 +236,16 @@ module wt_dcache_missunit #(
 ///////////////////////////////////////////////////////
 
   logic sc_fail, sc_pass, sc_backoff_over;
-  assign sc_backoff_over = 1'b1;
-  // exp_backoff #(
-  //   .Seed(3),
-  //   .MaxExp(16)
-  // ) i_exp_backoff (
-  //   .clk_i,
-  //   .rst_ni,
-  //   .set_i     ( sc_fail         ),
-  //   .clr_i     ( sc_pass         ),
-  //   .is_zero_o ( sc_backoff_over )
-  // );
+  exp_backoff #(
+    .Seed(3),
+    .MaxExp(16)
+  ) i_exp_backoff (
+    .clk_i,
+    .rst_ni,
+    .set_i     ( sc_fail         ),
+    .clr_i     ( sc_pass         ),
+    .is_zero_o ( sc_backoff_over )
+  );
 
 ///////////////////////////////////////////////////////
 // responses from memory
@@ -475,8 +474,8 @@ module wt_dcache_missunit #(
       AMO: begin
         mem_data_o.rtype = DCACHE_ATOMIC_REQ;
         amo_sel          = 1'b1;
-        // if this is an SC, we need to consult the backoff counter
-        if ((amo_req_i.amo_op != AMO_SC) || sc_backoff_over) begin
+        // if this is an LR, we need to consult the backoff counter
+        if ((amo_req_i.amo_op != AMO_LR) || sc_backoff_over) begin
           mem_data_req_o   = 1'b1;
           if (mem_data_ack_i) begin
             state_d = AMO_WAIT;


### PR DESCRIPTION
Enabled the backoff module.
Changed to wait before sending AMO_LR instead of AMO_SC to guarantee someone could make progress.  
Added the exp_backoff module in Flist.ariane and Bender.