### PR TITLE
Add global history predictor (Fix issue #126)

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -37,6 +37,7 @@ package ariane_pkg;
       int                               RASDepth;
       int                               BTBEntries;
       int                               BHTEntries;
+      int                               GHRLength;
       // PMAs
       int unsigned                      NrNonIdempotentRules;  // Number of non idempotent rules
       logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase; // base which needs to match
@@ -58,6 +59,7 @@ package ariane_pkg;
       RASDepth: 2,
       BTBEntries: 32,
       BHTEntries: 128,
+      GHRLength: 4,
       // idempotent region
       NrNonIdempotentRules: 2,
       NonIdempotentAddrBase: {64'b0, 64'b0},
@@ -281,6 +283,10 @@ package ariane_pkg;
     localparam NR_ALIGN_BITS = $clog2(FETCH_WIDTH/8);
     // maximum instructions we can fetch on one request (we support compressed instructions)
     localparam int unsigned INSTR_PER_FETCH = FETCH_WIDTH / 16;
+    // tag bits in branch prediction table
+    localparam int unsigned TAG_BITS = 10;
+    // fetch target queue depth
+    localparam int unsigned FTQ_FIFO_DEPTH = 8;
 
     // Only use struct when signals have same direction
     // exception
@@ -665,6 +671,7 @@ package ariane_pkg;
         logic                     kill_s1;                // kill the current request
         logic                     kill_s2;                // kill the last request
         logic [63:0]              vaddr;                  // 1st cycle: 12 bit index is taken for lookup
+        logic                     replay;                 // is this request a replay
     } icache_dreq_i_t;
 
     typedef struct packed {
@@ -673,6 +680,7 @@ package ariane_pkg;
         logic [FETCH_WIDTH-1:0]   data;                   // 2+ cycle out: tag
         logic [63:0]              vaddr;                  // virtual address out
         exception_t               ex;                     // we've encountered an exception
+        logic                     replay;                 // is this request from a replay
     } icache_dreq_o_t;
 
     // AMO request going to cache. this request is unconditionally valid as soon

--- a/src/branch_unit.sv
+++ b/src/branch_unit.sv
@@ -65,11 +65,15 @@ module branch_unit (
             resolved_branch_o.target_address = (branch_comp_res_i) ? target_address : next_pc;
             resolved_branch_o.is_taken = branch_comp_res_i;
             // check the outcome of the branch speculation
-            if (ariane_pkg::is_branch(fu_data_i.operator) && branch_comp_res_i != (branch_predict_i.cf == ariane_pkg::Branch)) begin
+            if (ariane_pkg::is_branch(fu_data_i.operator)) begin
+                // we need to set the cf_type to Branch in both taken and not-taken predictions
+                // to update the bht properly
+                resolved_branch_o.cf_type = ariane_pkg::Branch;
                 // we mis-predicted the outcome
                 // if the outcome doesn't match we've got a mis-predict
-                resolved_branch_o.is_mispredict  = 1'b1;
-                resolved_branch_o.cf_type = ariane_pkg::Branch;
+                if (branch_comp_res_i != (branch_predict_i.cf == ariane_pkg::Branch)) begin
+                    resolved_branch_o.is_mispredict  = 1'b1;
+                end
             end
             if (fu_data_i.operator == ariane_pkg::JALR
                 // check if the address of the jump register is correct and that we actually predicted

--- a/src/frontend/bht.sv
+++ b/src/frontend/bht.sv
@@ -16,14 +16,23 @@
 // branch history table - 2 bit saturation counter
 module bht #(
     parameter int unsigned NR_ENTRIES = 1024,
-    parameter int unsigned NR_GLOBAL_HISTORIES = 8
+    parameter int unsigned NR_GLOBAL_HISTORIES = 4
 )(
-    input  logic                        clk_i,
-    input  logic                        rst_ni,
-    input  logic                        flush_i,
-    input  logic                        debug_mode_i,
-    input  logic [63:0]                 vpc_i,
-    input  ariane_pkg::bht_update_t     bht_update_i,
+    input  logic                                    clk_i,
+    input  logic                                    rst_ni,
+    input  logic                                    flush_i,
+    input  logic                                    flush_ftq_i,
+    input  logic                                    debug_mode_i,
+    input  logic [63:0]                             vpc_i,
+    input  logic                                    instr_queue_overflow_i,
+    input  logic [63:0]                             instr_queue_replay_addr_i,
+    input  logic                                    serving_unaligned_i, // we have an unalinged instruction at the beginning
+    input  ariane_pkg::bht_update_t                 bht_update_i,
+    input  logic [ariane_pkg::INSTR_PER_FETCH-1:0]  valid_i,
+    input  logic [ariane_pkg::INSTR_PER_FETCH-1:0]  is_branch_i,
+    input  logic [ariane_pkg::INSTR_PER_FETCH-1:0]  taken_rvi_cf_i,
+    input  logic [ariane_pkg::INSTR_PER_FETCH-1:0]  taken_rvc_cf_i,
+    output logic                                    ftq_overflow_o,
     // we potentially need INSTR_PER_FETCH predictions/cycle
     output ariane_pkg::bht_prediction_t [ariane_pkg::INSTR_PER_FETCH-1:0] bht_prediction_o
 );
@@ -35,36 +44,154 @@ module bht #(
     localparam ROW_ADDR_BITS = $clog2(ariane_pkg::INSTR_PER_FETCH);
     // number of bits we should use for prediction
     localparam PREDICTION_BITS = $clog2(NR_ROWS) + OFFSET + ROW_ADDR_BITS;
-    // we are not interested in all bits of the address
+    // number of bits of the table index
+    localparam INDEX_BITS = $clog2(NR_ROWS);
+
+    localparam NR_GLOBAL_HISTORIES_REMAINDER = NR_GLOBAL_HISTORIES % INDEX_BITS;
+    localparam EXTENDED_GHR_LEN = INDEX_BITS > NR_GLOBAL_HISTORIES ? INDEX_BITS :
+				                            (NR_GLOBAL_HISTORIES_REMAINDER == 0 ? NR_GLOBAL_HISTORIES :
+                                    (NR_GLOBAL_HISTORIES + INDEX_BITS - NR_GLOBAL_HISTORIES_REMAINDER));
+
+    // we are not interested in a ll bits of the address
     unread i_unread (.d_i(|vpc_i));
 
     // global history register
     logic [NR_GLOBAL_HISTORIES-1:0] ghr_d, ghr_q;
 
+    // this is the struct which provide the information from the branch predictor
+    // and we will use it to update the branch history table.
+    typedef struct packed {
+        logic [INDEX_BITS-1:0] gshare_index;
+        logic [$clog2(ariane_pkg::INSTR_PER_FETCH):0] bp_count;  // count how many valid branch predictions in this fetch
+        logic serving_unaligned;
+        logic [ariane_pkg::TAG_BITS-1:0] tag;
+    } ftq_entry_t;
+
+    // signals to make the predictions
+    logic [63:0] realigned_vpc;
+    logic [EXTENDED_GHR_LEN-1:0] extended_ghr;
+    logic [$clog2(NR_ROWS)-1:0] gshare_index;
+    logic [ariane_pkg::INSTR_PER_FETCH-1:0] valid_taken_cf;
+    logic [ariane_pkg::INSTR_PER_FETCH-1:0] is_replay;  // replay logic per instruction
+    logic [ariane_pkg::INSTR_PER_FETCH-1:0] is_valid_branch;
+    logic [$clog2(ariane_pkg::INSTR_PER_FETCH)-1:0] replay_pos;
+
+    // fetch target queue signals
+    logic [$clog2(ariane_pkg::FETCH_FIFO_DEPTH)-1:0] ftq_usage;
+    ftq_entry_t  ftq_entry_i, ftq_entry_o;
+    logic pop_ftq, push_ftq;
+    logic full_ftq;
+    logic empty_ftq;
+
+    // count the number of rest valid predictions in that entry
+    logic [$clog2(ariane_pkg::INSTR_PER_FETCH):0] bp_count_d, bp_count_q;
+    logic [$clog2(ariane_pkg::INSTR_PER_FETCH):0] pop_count;
+
     struct packed {
-        logic       valid;
         logic [1:0] saturation_counter;
+        logic [ariane_pkg::TAG_BITS-1:0] tag;
     } bht_d[NR_ROWS-1:0][ariane_pkg::INSTR_PER_FETCH-1:0], bht_q[NR_ROWS-1:0][ariane_pkg::INSTR_PER_FETCH-1:0];
 
-    logic [$clog2(NR_ROWS)-1:0]  index, update_pc;
+    // update the prediction table
+    logic                        is_unaligned_instr;
+    logic [63:0]                 realigned_update_pc;
+    logic [$clog2(NR_ROWS)-1:0]  update_pc;
     logic [ROW_ADDR_BITS-1:0]    update_row_index;
     logic [1:0]                  saturation_counter;
 
-    assign index     = vpc_i[PREDICTION_BITS - 1:ROW_ADDR_BITS + OFFSET];
-    assign update_pc = bht_update_i.pc[PREDICTION_BITS - 1:ROW_ADDR_BITS + OFFSET];
-    assign update_row_index = bht_update_i.pc[ROW_ADDR_BITS + OFFSET - 1:OFFSET];
+    // compute the index using gshare predictor
+    // if the global history is shorter than the index bits, simply xor them
+    // if the global history is longer than the index bits, than we do folded xor
+    // for example, if the history is 1 0 1 0 1 1 1 1 and the index bits are 0 1 1
+    // then we compute gshare index as (110) ^ (101) ^ (111) ^ (011)
+    always_comb begin : gen_gshare_index
+        gshare_index = realigned_vpc[PREDICTION_BITS - 1:ROW_ADDR_BITS + OFFSET];
+        // extend global history register to the length of multiplication of index bits
+        extended_ghr = {{{INDEX_BITS-NR_GLOBAL_HISTORIES_REMAINDER}{1'b1}}, ghr_q};
+        for (int unsigned i = 0; i < NR_GLOBAL_HISTORIES; i = i + INDEX_BITS) begin
+            gshare_index ^= extended_ghr[i +: INDEX_BITS];
+        end
+    end
+
+    // check if the instructions are valid control flows
+    assign valid_taken_cf = valid_i & (taken_rvc_cf_i | taken_rvi_cf_i);
+    // realigned pc address to fetch block width
+    assign realigned_vpc = {vpc_i[63:ROW_ADDR_BITS+1], (ROW_ADDR_BITS+1)'(0)};
+    assign ftq_entry_i = { gshare_index,                                                  // gshare index
+                           pop_count,                                                     // valid branch prediction count
+                           serving_unaligned_i,                                           // serving an unaligned instruction
+                           realigned_vpc[ROW_ADDR_BITS + OFFSET +: ariane_pkg::TAG_BITS]  // tag
+                         };
+    assign push_ftq = (|is_valid_branch);
+
+    assign realigned_update_pc = bht_update_i.pc + (1<<$clog2(ariane_pkg::INSTR_PER_FETCH));
+    assign is_unaligned_instr = ftq_entry_o.serving_unaligned
+                                & (bht_update_i.pc[ROW_ADDR_BITS + OFFSET - 1:OFFSET] == {ROW_ADDR_BITS{1'b1}});
+    assign pop_ftq = bht_update_i.valid & ((bp_count_q == 1) || ftq_entry_o.bp_count == 1);
+    assign update_row_index = is_unaligned_instr ? 0 : bht_update_i.pc[ROW_ADDR_BITS + OFFSET - 1:OFFSET];
+    assign update_pc = ftq_entry_o.gshare_index;
+    assign ftq_overflow_o = full_ftq & push_ftq;
+
+    // if replay starts from an unaglined address, replay position should be 0.
+    assign replay_pos = serving_unaligned_i ? 0 : instr_queue_replay_addr_i[$clog2(ariane_pkg::INSTR_PER_FETCH):1];
+    // if the incoming instruction is a replay at the replay address, then the rest of the fetched
+    // instruction should also be replay. For example, in 64 bit fetch if the replay starts from 0x42,
+    // the replay mask should be 1 1 1 0 from the highest to lowest.
+    assign is_replay = {ariane_pkg::INSTR_PER_FETCH{instr_queue_overflow_i}} << replay_pos;
+    // an instruction is a valid branch instruction to push to fetch target queue if:
+    // 1) it is a valid branch instruction
+    // 2) it is not a replay
+    // 3) no taken control flow before it in the same fetch block
+    for (genvar i = 0; i < ariane_pkg::INSTR_PER_FETCH; i++) begin
+        if (i == 0) begin
+            assign is_valid_branch[i] = is_branch_i[i] & ~is_replay[i];
+        end else begin
+            assign is_valid_branch[i] = is_branch_i[i] & ~(|valid_taken_cf[i-1:0]) & ~is_replay[i];
+        end
+    end
 
     // prediction assignment
     for (genvar i = 0; i < ariane_pkg::INSTR_PER_FETCH; i++) begin : gen_bht_output
-        assign bht_prediction_o[i].valid = bht_q[index][i].valid;
-        assign bht_prediction_o[i].taken = bht_q[index][i].saturation_counter[1] == 1'b1;
+        assign bht_prediction_o[i].valid = bht_q[ftq_entry_i.gshare_index][i].tag == ftq_entry_i.tag;
+        assign bht_prediction_o[i].taken = bht_q[ftq_entry_i.gshare_index][i].saturation_counter[1] == 1'b1;
     end
+
+    // count the numbers of valid branch predictions in this fetch
+    popcount #(
+      .INPUT_WIDTH   ( ariane_pkg::INSTR_PER_FETCH )
+    ) i_popcount_bp (
+      .data_i     ( is_valid_branch ),
+      .popcount_o ( pop_count       )
+    );
+
+    fifo_v3 #(
+      .DEPTH      ( ariane_pkg::FTQ_FIFO_DEPTH   ),
+      .dtype      ( ftq_entry_t                  )
+    ) i_fifo_ftq (
+      .clk_i      ( clk_i                        ),
+      .rst_ni     ( rst_ni                       ),
+      .flush_i    ( flush_i | flush_ftq_i        ),
+      .testmode_i ( 1'b0                         ),
+      .full_o     ( full_ftq                     ),
+      .empty_o    ( empty_ftq                    ),
+      .usage_o    ( ftq_usage                    ),
+      .data_i     ( ftq_entry_i                  ),
+      .push_i     ( push_ftq & ~full_ftq         ),
+      .data_o     ( ftq_entry_o                  ),
+      .pop_i      ( pop_ftq                      )
+    );
 
     always_comb begin : update_bht
         bht_d = bht_q;
         saturation_counter = bht_q[update_pc][update_row_index].saturation_counter;
 
         ghr_d = ghr_q;
+
+        if (bp_count_q == '0) begin
+            bp_count_d = empty_ftq ? '0 : ftq_entry_o.bp_count;
+        end else begin
+            bp_count_d = bp_count_q;
+        end
 
         if (bht_update_i.valid && !debug_mode_i) begin
 
@@ -74,8 +201,23 @@ module bht #(
             end
             ghr_d[0] = bht_update_i.taken;
 
-            bht_d[update_pc][update_row_index].valid = 1'b1;
+            // update the valid branch prediction counter
+            // if the count is decreased to zero due to the previous bp, then the counter should be updated
+            // to the number of the new ftq entry. Else the counter should be decreased by 1.
+            if (bp_count_q == '0) begin
+                bp_count_d = ftq_entry_o.bp_count - 1;
+            end
+            else begin
+                bp_count_d = bp_count_q - 1;
+            end
 
+            if (bht_q[update_pc][update_row_index].tag != ftq_entry_o.tag) begin
+                // reset the counter
+                if (!bht_update_i.taken)
+                    bht_d[update_pc][update_row_index].saturation_counter = 2'b01;
+                else
+                    bht_d[update_pc][update_row_index].saturation_counter = 2'b10;
+            end else
             if (saturation_counter == 2'b11) begin
                 // we can safely decrease it
                 if (!bht_update_i.taken)
@@ -91,6 +233,10 @@ module bht #(
                 else
                     bht_d[update_pc][update_row_index].saturation_counter = saturation_counter - 1;
             end
+
+            // update the tag
+            bht_d[update_pc][update_row_index].tag = ftq_entry_o.tag;
+
         end
     end
 
@@ -102,12 +248,12 @@ module bht #(
                 end
             end
             ghr_q <= '0;
+            bp_count_q <= '0;
         end else begin
             // evict all entries
             if (flush_i) begin
                 for (int i = 0; i < NR_ROWS; i++) begin
                     for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
-                        bht_q[i][j].valid <=  1'b0;
                         bht_q[i][j].saturation_counter <= 2'b10;
                     end
                 end
@@ -115,6 +261,12 @@ module bht #(
             end else begin
                 bht_q <= bht_d;
                 ghr_q <= ghr_d;
+            end
+
+            if (flush_i || flush_ftq_i) begin
+                bp_count_q <= '0;
+            end else begin
+                bp_count_q <= bp_count_d;
             end
         end
     end

--- a/src/frontend/frontend.sv
+++ b/src/frontend/frontend.sv
@@ -63,8 +63,14 @@ module frontend #(
     // indicates whether we come out of reset (then we need to load boot_addr_i)
     logic          npc_rst_load_q;
 
+    // replay logic
     logic          replay;
     logic [63:0]   replay_addr;
+    logic [63:0]   instr_queue_replay_addr;
+    logic          instr_queue_overflow, ftq_overflow;
+    // replay if any of the queue overflows
+    assign replay = instr_queue_overflow | ftq_overflow;
+    assign replay_addr = ftq_overflow ? addr[0] : instr_queue_replay_addr;
 
     // shift amount
     // address will always be 16 bit aligned, make this explicit here
@@ -123,8 +129,9 @@ module frontend #(
     // --------------------
     // select the right branch prediction result
     // in case we are serving an unaligned instruction in instr[0] we need to take
-    // the prediction we saved from the previous fetch
-    assign bht_prediction_shifted[0] = (serving_unaligned) ? bht_q : bht_prediction[0];
+    // the prediction targe we saved, but the for the prediction result we fetch the
+    // first prediction since we store the unaligned update in an alinged address.
+    assign bht_prediction_shifted[0] = (serving_unaligned) ? bht_prediction[0] : bht_prediction[addr[0][$clog2(INSTR_PER_FETCH):1]];
     assign btb_prediction_shifted[0] = (serving_unaligned) ? btb_q : btb_prediction[0];
     // for all other predictions we can use the generated address to index
     // into the branch prediction data structures
@@ -372,15 +379,25 @@ module frontend #(
     );
 
     bht #(
-      .NR_ENTRIES       ( ArianeCfg.BHTEntries   )
+      .NR_ENTRIES            ( ArianeCfg.BHTEntries              ),
+      .NR_GLOBAL_HISTORIES   ( ArianeCfg.GHRLength               )
     ) i_bht (
       .clk_i,
       .rst_ni,
-      .flush_i          ( flush_bp_i       ),
+      .flush_i                    ( flush_bp_i                       ),
+      .flush_ftq_i                ( flush_i                          ),
       .debug_mode_i,
-      .vpc_i            ( icache_vaddr_q   ),
-      .bht_update_i     ( bht_update       ),
-      .bht_prediction_o ( bht_prediction   )
+      .vpc_i                      ( icache_vaddr_q                   ),
+      .instr_queue_overflow_i     ( instr_queue_overflow             ), // from instruction queue
+      .instr_queue_replay_addr_i  ( instr_queue_replay_addr          ),
+      .is_branch_i                ( is_branch                        ),
+      .valid_i                    ( instruction_valid                ),
+      .serving_unaligned_i        ( serving_unaligned                ),
+      .taken_rvc_cf_i             ( taken_rvc_cf                     ),
+      .taken_rvi_cf_i             ( taken_rvi_cf                     ),
+      .bht_update_i               ( bht_update                       ),
+      .ftq_overflow_o             ( ftq_overflow                     ),
+      .bht_prediction_o           ( bht_prediction                   )
     );
 
     // we need to inspect up to INSTR_PER_FETCH instructions for branches
@@ -415,9 +432,10 @@ module frontend #(
       .cf_type_i           ( cf_type              ),
       .valid_i             ( instruction_valid    ), // from re-aligner
       .consumed_o          ( instr_queue_consumed ),
+      .ftq_overflow_i      ( ftq_overflow         ), // from branch predictor
       .ready_o             ( instr_queue_ready    ),
-      .replay_o            ( replay               ),
-      .replay_addr_o       ( replay_addr          ),
+      .overflow_o          ( instr_queue_overflow ),
+      .replay_addr_o       ( instr_queue_replay_addr ),
       .fetch_entry_o       ( fetch_entry_o        ), // to back-end
       .fetch_entry_valid_o ( fetch_entry_valid_o  ), // to back-end
       .fetch_entry_ready_i ( fetch_entry_ready_i  )  // to back-end

--- a/src/frontend/instr_queue.sv
+++ b/src/frontend/instr_queue.sv
@@ -57,8 +57,10 @@ module instr_queue (
   // branch predict
   input  logic [63:0]                                        predict_address_i,
   input  ariane_pkg::cf_t  [ariane_pkg::INSTR_PER_FETCH-1:0] cf_type_i,
+  // input from branch predictor to see if the fetch target queue overflows
+  input  logic                                               ftq_overflow_i,
   // replay instruction because one of the FIFO was already full
-  output logic                                               replay_o,
+  output logic                                               overflow_o,
   output logic [63:0]                                        replay_addr_o, // address at which to replay this instruction
   // to processor backend
   output ariane_pkg::fetch_entry_t                           fetch_entry_o,
@@ -86,6 +88,7 @@ module instr_queue (
   logic [$clog2(ariane_pkg::FETCH_FIFO_DEPTH)-1:0] address_queue_usage;
   logic [63:0] address_out;
   logic pop_address;
+  logic valid_cf_push;
   logic push_address;
   logic full_address;
   logic empty_address;
@@ -103,8 +106,8 @@ module instr_queue (
   logic branch_empty;
   logic [ariane_pkg::INSTR_PER_FETCH-1:0] taken;
   // shift amount, e.g.: instructions we want to retire
-  logic [$clog2(ariane_pkg::INSTR_PER_FETCH):0] popcount;
-  logic [$clog2(ariane_pkg::INSTR_PER_FETCH)-1:0] shamt;
+  logic [$clog2(ariane_pkg::INSTR_PER_FETCH):0] popcount, popcount_push_instr;
+  logic [$clog2(ariane_pkg::INSTR_PER_FETCH)-1:0] shamt, shamt_push_instr;
   logic [ariane_pkg::INSTR_PER_FETCH-1:0] valid;
   logic [ariane_pkg::INSTR_PER_FETCH*2-1:0] consumed_extended;
   // FIFO mask
@@ -193,14 +196,22 @@ module instr_queue (
   // if one of the FIFOs was full we need to replay the faulting instruction
   assign instr_overflow_fifo = instr_queue_full & fifo_pos;
   assign instr_overflow = |instr_overflow_fifo; // at least one instruction overflowed
-  assign address_overflow = full_address & push_address;
-  assign replay_o = instr_overflow | address_overflow;
+  assign address_overflow = full_address & valid_cf_push;
+  assign overflow_o = instr_overflow | address_overflow;
 
   // select the address, in the case of an address fifo overflow just
   // use the base of this package
   // if we successfully pushed some instructions we can output the next instruction
   // which we didn't manage to push
-  assign replay_addr_o = (address_overflow) ? addr_i[0] : addr_i[shamt];
+  // this count doesn't include other overflows
+  popcount #(
+    .INPUT_WIDTH   ( ariane_pkg::INSTR_PER_FETCH )
+  ) i_popcount_push_instr (
+    .data_i     ( push_instr          ),
+    .popcount_o ( popcount_push_instr )
+  );
+  assign shamt_push_instr = popcount_push_instr[$bits(shamt_push_instr)-1:0];
+  assign replay_addr_o = address_overflow ? addr_i[0] : addr_i[shamt_push_instr];
 
   // ----------------------
   // Downstream interface
@@ -267,7 +278,7 @@ module instr_queue (
   // FIFOs
   for (genvar i = 0; i < ariane_pkg::INSTR_PER_FETCH; i++) begin : gen_instr_fifo
     // Make sure we don't save any instructions if we couldn't save the address
-    assign push_instr_fifo[i] = push_instr[i] & ~address_overflow;
+    assign push_instr_fifo[i] = push_instr[i] & ~address_overflow & ~ftq_overflow_i;
     fifo_v3 #(
       .DEPTH      ( ariane_pkg::FETCH_FIFO_DEPTH ),
       .dtype      ( instr_data_t                 )
@@ -288,11 +299,12 @@ module instr_queue (
   // or reduce and check whether we are retiring a taken branch (might be that the corresponding)
   // fifo is full.
   always_comb begin
-    push_address = 1'b0;
+    valid_cf_push = 1'b0;
     // check if we are pushing a ctrl flow change, if so save the address
     for (int i = 0; i < ariane_pkg::INSTR_PER_FETCH; i++) begin
-      push_address |= push_instr[i] & (instr_data_in[i].cf != ariane_pkg::NoCF);
+      valid_cf_push |= push_instr[i] & (instr_data_in[i].cf != ariane_pkg::NoCF);
     end
+    push_address = valid_cf_push & ~full_address & ~ftq_overflow_i;
   end
 
   fifo_v3 #(
@@ -307,7 +319,7 @@ module instr_queue (
     .empty_o    ( empty_address                ),
     .usage_o    ( address_queue_usage          ),
     .data_i     ( predict_address_i            ),
-    .push_i     ( push_address & ~full_address ),
+    .push_i     ( push_address                 ),
     .data_o     ( address_out                  ),
     .pop_i      ( pop_address                  )
   );
@@ -343,7 +355,7 @@ module instr_queue (
   // pragma translate_off
   `ifndef VERILATOR
       replay_address_fifo: assert property (
-        @(posedge clk_i) disable iff (!rst_ni) replay_o |-> !i_fifo_address.push_i
+        @(posedge clk_i) disable iff (!rst_ni) (overflow_o & ftq_overflow_i) |-> !i_fifo_address.push_i
       ) else $fatal(1,"[instr_queue] Pushing address although replay asserted");
 
       output_select_onehot: assert property (

--- a/tb/ariane_soc_pkg.sv
+++ b/tb/ariane_soc_pkg.sv
@@ -70,6 +70,7 @@ package ariane_soc;
     RASDepth: 2,
     BTBEntries: 32,
     BHTEntries: 128,
+    GHRLength: 4,
     // idempotent region
     NrNonIdempotentRules:  0,
     NonIdempotentAddrBase: {64'b0},


### PR DESCRIPTION
Add a gshare global history predictor to enhance the performance and fix #126  
By compare the mispredictions on benchmarks, a global history register with length = 4 performed best. Here is the comparison between the original and the new branch predictor result.

![image](https://user-images.githubusercontent.com/16504355/61577673-4c0f8e80-ab1d-11e9-82a2-c190f246be50.png)


It doesn't perform well on qsort benchmark. My understanding is that in the insertion sort, the pattern between taken and untaken is not regular. It makes global history varies and make gshare harder to learn  the prediction. 

Synthesis test was run and passed.