### PR TITLE
Make fpu optional

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -153,15 +153,15 @@ package ariane_pkg;
     localparam int unsigned DEPTH_COMMIT = 8;
 `endif
 
-
-`ifdef PITON_ARIANE
+`define FPU_ENABLE // to enable both F and D extensions
+`ifdef FPU_ENABLE
     // Floating-point extensions configuration
     localparam bit RVF = 1'b1; // Is F extension enabled
     localparam bit RVD = 1'b1; // Is D extension enabled
 `else
     // Floating-point extensions configuration
-    localparam bit RVF = 1'b1; // Is F extension enabled
-    localparam bit RVD = 1'b1; // Is D extension enabled
+    localparam bit RVF = 1'b0; // Is F extension disabled
+    localparam bit RVD = 1'b0; // Is D extension disabled
 `endif
     localparam bit RVA = 1'b1; // Is A extension enabled
 

--- a/src/issue_stage.sv
+++ b/src/issue_stage.sv
@@ -97,6 +97,7 @@ module issue_stage #(
     logic                      issue_instr_valid_sb_iro;
     logic                      issue_ack_iro_sb;
 
+  
     // ---------------------------------------------------------
     // 1. Re-name
     // ---------------------------------------------------------
@@ -112,6 +113,7 @@ module issue_stage #(
         .issue_instr_valid_o    ( issue_instr_valid_rename_sb  ),
         .issue_ack_i            ( issue_ack_sb_rename          )
     );
+    
 
     // ---------------------------------------------------------
     // 2. Manage instructions in a scoreboard
@@ -131,9 +133,10 @@ module issue_stage #(
         .rs2_o                 ( rs2_sb_iro                                ),
         .rs2_valid_o           ( rs2_valid_iro_sb                          ),
         .rs3_i                 ( rs3_iro_sb                                ),
+      `ifdef FPU_ENABLE
         .rs3_o                 ( rs3_sb_iro                                ),
         .rs3_valid_o           ( rs3_valid_iro_sb                          ),
-
+      `endif
         .decoded_instr_i       ( issue_instr_rename_sb                     ),
         .decoded_instr_valid_i ( issue_instr_valid_rename_sb               ),
         .decoded_instr_ack_o   ( issue_ack_sb_rename                       ),
@@ -147,6 +150,11 @@ module issue_stage #(
         .ex_i                  ( ex_ex_i                                   ),
         .*
     );
+
+    `ifndef FPU_ENABLE
+       assign rs3_sb_iro = '0;
+       assign rs3_valid_iro_sb = '1;
+    `endif
 
     // ---------------------------------------------------------
     // 3. Issue instruction and read operand, also commit

--- a/src/scoreboard.sv
+++ b/src/scoreboard.sv
@@ -37,9 +37,11 @@ module scoreboard #(
   output logic                                                  rs2_valid_o,
 
   input  logic [ariane_pkg::REG_ADDR_SIZE-1:0]                  rs3_i,
+`ifdef FPU_ENABLE
   output logic [ariane_pkg::FLEN-1:0]                           rs3_o,
   output logic                                                  rs3_valid_o,
-
+`endif
+  
   // advertise instruction to commit stage, if commit_ack_i is asserted advance the commit pointer
   output ariane_pkg::scoreboard_entry_t [NR_COMMIT_PORTS-1:0]   commit_instr_o,
   input  logic              [NR_COMMIT_PORTS-1:0]               commit_ack_i,
@@ -316,6 +318,7 @@ module scoreboard #(
     .idx_o   (             )
   );
 
+`ifdef FPU_ENABLE
   rr_arb_tree #(
     .NumIn(NR_ENTRIES+NR_WB_PORTS),
     .DataWidth(64),
@@ -334,7 +337,8 @@ module scoreboard #(
     .data_o  ( rs3_o       ),
     .idx_o   (             )
   );
-
+`endif
+  
   // sequential process
   always_ff @(posedge clk_i or negedge rst_ni) begin : regs
     if(!rst_ni) begin


### PR DESCRIPTION
As FPU size is significant (114 equivalent kgates in our techno), it is critical to have the capability to remove it if it is not used by our product.

To disable the FPU, RVD and RVF are set to zero. With this configuration, the resulting RTL cannot be elaborated by the Synopsys dc_shell tool.

The proposed modification solves the issue.

Regards,
Jean-Roch