### PR TITLE
Fix support_verilator_4 detection for bash and add optimization to verilator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BOARD          ?= genesys2
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 root-dir := $(dir $(mkfile_path))
 
-support_verilator_4 := $(shell (verilator --version | grep '4\.') &> /dev/null; echo $$?)
+support_verilator_4 := $(shell (verilator --version | grep '4\.') > /dev/null; echo $$?)
 ifeq ($(support_verilator_4), 0)
 	verilator_threads := 2
 endif

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ dpi_hdr := $(wildcard tb/dpi/*.h)
 dpi_hdr := $(addprefix $(root-dir), $(dpi_hdr))
 CFLAGS := -I$(QUESTASIM_HOME)/include         \
           -I$(RISCV)/include                  \
-          -std=c++11 -I../tb/dpi
+          -std=c++11 -I../tb/dpi -O2
 
 ifdef spike-tandem
     CFLAGS += -Itb/riscv-isa-sim/install/include/spike


### PR DESCRIPTION
On our system with bash, even if we have verilator 4 properly set up,
ariane's Makefile will not set support_verilator_4, leaving the
verilator output to be single threaded. This patch adds our fix to this
issue. In addition, -O2 option is added to CFLAGS when compiling
verilate target.