### PR TITLE
ariane.cfg: enable address translation per default when debugging

### DIFF
--- a/fpga/ariane.cfg
+++ b/fpga/ariane.cfg
@@ -34,7 +34,10 @@ riscv set_command_timeout_sec 120
 
 # prefer to use sba for system bus access
 riscv set_prefer_sba off
-riscv set_enable_virtual on
+
+# Try enabling address translation (only works for newer versions)
+if { [catch {riscv set_enable_virtual on} ] } {
+    echo "Warning: This version of OpenOCD does not support address translation. To debug on virtual addresses, please update to the latest version." }
 
 init
 halt

--- a/fpga/ariane.cfg
+++ b/fpga/ariane.cfg
@@ -34,6 +34,7 @@ riscv set_command_timeout_sec 120
 
 # prefer to use sba for system bus access
 riscv set_prefer_sba off
+riscv set_enable_virtual on
 
 init
 halt


### PR DESCRIPTION
Enable the OpenOCD option to perform memory accesses according to the current privilege level as per https://github.com/riscv/riscv-openocd/pull/386.
i.e. when debug mode is entered from a context running on virtual memory, address translation is performed for memory reads and writes through the debugger.