### PR TITLE
load_unit: Fix #356 uncached loads served from WB

### DIFF
--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -408,7 +408,8 @@ module ariane #(
     .icache_areq_o          ( icache_areq_ex_cache        ),
     // DCACHE interfaces
     .dcache_req_ports_i     ( dcache_req_ports_cache_ex   ),
-    .dcache_req_ports_o     ( dcache_req_ports_ex_cache   )
+    .dcache_req_ports_o     ( dcache_req_ports_ex_cache   ),
+    .dcache_wbuffer_empty_i ( dcache_commit_wbuffer_empty )
   );
 
   // ---------

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -125,6 +125,7 @@ module ariane #(
   // LSU Commit
   logic                     lsu_commit_commit_ex;
   logic                     lsu_commit_ready_ex_commit;
+  logic [TRANS_ID_BITS-1:0] lsu_commit_trans_id;
   logic                     no_st_pending_ex;
   logic                     no_st_pending_commit;
   logic                     amo_valid_commit;
@@ -376,6 +377,7 @@ module ariane #(
 
     .lsu_commit_i           ( lsu_commit_commit_ex        ), // from commit
     .lsu_commit_ready_o     ( lsu_commit_ready_ex_commit  ), // to commit
+    .commit_tran_id_i       ( lsu_commit_trans_id         ), // from commit
     .no_st_pending_o        ( no_st_pending_ex            ),
     // FPU
     .fpu_ready_o            ( fpu_ready_ex_id             ),
@@ -437,6 +439,7 @@ module ariane #(
     .we_fpr_o               ( we_fpr_commit_id              ),
     .commit_lsu_o           ( lsu_commit_commit_ex          ),
     .commit_lsu_ready_i     ( lsu_commit_ready_ex_commit    ),
+    .commit_tran_id_o       ( lsu_commit_trans_id           ),
     .amo_valid_commit_o     ( amo_valid_commit              ),
     .amo_resp_i             ( amo_resp                      ),
     .commit_csr_o           ( csr_commit_commit_ex          ),

--- a/src/commit_stage.sv
+++ b/src/commit_stage.sv
@@ -45,6 +45,7 @@ module commit_stage #(
     // commit signals to ex
     output logic                                    commit_lsu_o,       // commit the pending store
     input  logic                                    commit_lsu_ready_i, // commit buffer of LSU is ready
+    output logic [TRANS_ID_BITS-1:0]                commit_tran_id_o,   // transaction id of first commit port
     output logic                                    amo_valid_commit_o, // valid AMO in commit stage
     input  logic                                    no_st_pending_i,    // there is no store pending
     output logic                                    commit_csr_o,       // commit the pending CSR instruction
@@ -80,6 +81,8 @@ module commit_stage #(
         dirty_fp_state_o |= commit_ack_o[i] & (commit_instr_i[i].fu inside {FPU, FPU_VEC} || is_rd_fpr(commit_instr_i[i].op));
       end
     end
+
+    assign commit_tran_id_o = commit_instr_i[0].trans_id;
 
     logic instr_0_is_amo;
     assign instr_0_is_amo = is_amo(commit_instr_i[0].op);

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -62,6 +62,7 @@ module ex_stage #(
 
     input  logic                                   lsu_commit_i,
     output logic                                   lsu_commit_ready_o, // commit queue is ready to accept another commit request
+    input  logic [TRANS_ID_BITS-1:0]               commit_tran_id_i,
     output logic                                   no_st_pending_o,
     input  logic                                   amo_valid_commit_i,
     // FPU
@@ -276,6 +277,7 @@ module ex_stage #(
         .store_exception_o,
         .commit_i              ( lsu_commit_i       ),
         .commit_ready_o        ( lsu_commit_ready_o ),
+        .commit_tran_id_i,
         .enable_translation_i,
         .en_ld_st_translation_i,
         .icache_areq_i,

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -93,6 +93,7 @@ module ex_stage #(
     // interface to dcache
     input  dcache_req_o_t [2:0]                    dcache_req_ports_i,
     output dcache_req_i_t [2:0]                    dcache_req_ports_o,
+    input  logic                                   dcache_wbuffer_empty_i,
     output amo_req_t                               amo_req_o,          // request to cache subsytem
     input  amo_resp_t                              amo_resp_i,         // response from cache subsystem
     // Performance counters
@@ -290,6 +291,7 @@ module ex_stage #(
         .dtlb_miss_o,
         .dcache_req_ports_i,
         .dcache_req_ports_o,
+        .dcache_wbuffer_empty_i,
         .amo_valid_commit_i,
         .amo_req_o,
         .amo_resp_i

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -62,6 +62,7 @@ module load_store_unit #(
     // interface to dcache
     input  dcache_req_o_t [2:0]      dcache_req_ports_i,
     output dcache_req_i_t [2:0]      dcache_req_ports_o,
+    input  logic                     dcache_wbuffer_empty_i,
     // AMO interface
     output amo_req_t                 amo_req_o,
     input  amo_resp_t                amo_resp_i
@@ -180,7 +181,9 @@ module load_store_unit #(
     // ------------------
     // Load Unit
     // ------------------
-    load_unit i_load_unit (
+    load_unit #(
+        .ArianeCfg ( ArianeCfg )
+    ) i_load_unit (
         .valid_i               ( ld_valid_i           ),
         .lsu_ctrl_i            ( lsu_ctrl             ),
         .pop_ld_o              ( pop_ld               ),
@@ -201,6 +204,7 @@ module load_store_unit #(
         // to memory arbiter
         .req_port_i            ( dcache_req_ports_i [1] ),
         .req_port_o            ( dcache_req_ports_o [1] ),
+        .dcache_wbuffer_empty_i,
         .*
     );
 

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -40,6 +40,7 @@ module load_store_unit #(
 
     input  logic                     commit_i,                 // commit the pending store
     output logic                     commit_ready_o,           // commit queue is ready to accept another commit request
+    input  logic [TRANS_ID_BITS-1:0] commit_tran_id_i,
 
     input  logic                     enable_translation_i,     // enable virtual memory translation
     input  logic                     en_ld_st_translation_i,   // enable virtual memory translation for load/stores
@@ -141,6 +142,7 @@ module load_store_unit #(
         .icache_areq_o          ( icache_areq_o          ),
         .*
     );
+    logic store_buffer_empty;
     // ------------------
     // Store Unit
     // ------------------
@@ -149,6 +151,7 @@ module load_store_unit #(
         .rst_ni,
         .flush_i,
         .no_st_pending_o,
+        .store_buffer_empty_o  ( store_buffer_empty   ),
 
         .valid_i               ( st_valid_i           ),
         .lsu_ctrl_i            ( lsu_ctrl             ),
@@ -201,10 +204,12 @@ module load_store_unit #(
         // to store unit
         .page_offset_o         ( page_offset          ),
         .page_offset_matches_i ( page_offset_matches  ),
+        .store_buffer_empty_i  ( store_buffer_empty   ),
         // to memory arbiter
         .req_port_i            ( dcache_req_ports_i [1] ),
         .req_port_o            ( dcache_req_ports_o [1] ),
         .dcache_wbuffer_empty_i,
+        .commit_tran_id_i,
         .*
     );
 

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -13,9 +13,9 @@
 // Date: 15.08.2018
 // Description: Load Unit, takes care of all load requests
 
-import ariane_pkg::*;
-
-module load_unit (
+module load_unit import ariane_pkg::*; #(
+    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+) (
     input  logic                     clk_i,    // Clock
     input  logic                     rst_ni,   // Asynchronous reset active low
     input  logic                     flush_i,
@@ -39,10 +39,12 @@ module load_unit (
     input  logic                     page_offset_matches_i,
     // D$ interface
     input dcache_req_o_t             req_port_i,
-    output dcache_req_i_t            req_port_o
+    output dcache_req_i_t            req_port_o,
+    input  logic                     dcache_wbuffer_empty_i
 );
-    enum logic [2:0] { IDLE, WAIT_GNT, SEND_TAG, WAIT_PAGE_OFFSET,
-                       ABORT_TRANSACTION, WAIT_TRANSLATION, WAIT_FLUSH
+    enum logic [3:0] { IDLE, WAIT_GNT, SEND_TAG, WAIT_PAGE_OFFSET,
+                       ABORT_TRANSACTION, ABORT_TRANSACTION_NC, WAIT_TRANSLATION, WAIT_FLUSH,
+                       WAIT_WB_EMPTY
                      } state_d, state_q;
     // in order to decouple the response interface from the request interface we need a
     // a queue which can hold all outstanding memory requests
@@ -70,6 +72,12 @@ module load_unit (
                                               ariane_pkg::DCACHE_INDEX_WIDTH];
     // directly output an exception
     assign ex_o = ex_i;
+
+    logic stall_nc;  // stall because of non-empty WB and address within non-cacheable region.
+    // should we stall the request e.g.: is it withing a non-cacheable region
+    // and the write buffer is not empty so that we don't forward anything
+    // from the write buffer (e.g. it would essentially be cached).
+    assign stall_nc = ~dcache_wbuffer_empty_i & is_inside_cacheable_regions(ArianeCfg, paddr_i);
 
     // ---------------
     // Load Control
@@ -102,12 +110,16 @@ module load_unit (
                         if (!req_port_i.data_gnt) begin
                             state_d = WAIT_GNT;
                         end else begin
-                            if (dtlb_hit_i) begin
+                            if (dtlb_hit_i && !stall_nc) begin
                                 // we got a grant and a hit on the DTLB so we can send the tag in the next cycle
                                 state_d = SEND_TAG;
                                 pop_ld_o = 1'b1;
-                            end else
+                            // translation valid but this is to NC and the WB is not yet empty.
+                            end else if (dtlb_hit_i && stall_nc) begin
+                                state_d = ABORT_TRANSACTION_NC;
+                            end else begin
                                 state_d = ABORT_TRANSACTION;
+                            end
                         end
                     end else begin
                         // wait for the store buffer to train and the page offset to not match anymore
@@ -127,11 +139,17 @@ module load_unit (
             // abort the previous request - free the D$ arbiter
             // we are here because of a TLB miss, we need to abort the current request and give way for the
             // PTW walker to satisfy the TLB miss
-            ABORT_TRANSACTION: begin
+            ABORT_TRANSACTION, ABORT_TRANSACTION_NC: begin
                 req_port_o.kill_req  = 1'b1;
                 req_port_o.tag_valid = 1'b1;
-                // redo the request by going back to the wait gnt state
-                state_d = WAIT_TRANSLATION;
+                // either re-do the request or wait until the WB is empty (depending on where we came from).
+                state_d = (state_q == ABORT_TRANSACTION_NC) ? WAIT_WB_EMPTY :  WAIT_TRANSLATION;
+            end
+
+            // Wait until the write-back buffer is empty in the data cache.
+            WAIT_WB_EMPTY: begin
+                // the write buffer is empty, so lets go and re-do the translation.
+                if (dcache_wbuffer_empty_i) state_d = WAIT_TRANSLATION;
             end
 
             WAIT_TRANSLATION: begin
@@ -149,11 +167,16 @@ module load_unit (
                 // we finally got a data grant
                 if (req_port_i.data_gnt) begin
                     // so we send the tag in the next cycle
-                    if (dtlb_hit_i) begin
+                    if (dtlb_hit_i && !stall_nc) begin
                         state_d = SEND_TAG;
                         pop_ld_o = 1'b1;
-                    end else // should we not have hit on the TLB abort this transaction an retry later
+                    // translation valid but this is to NC and the WB is not yet empty.
+                    end else if (dtlb_hit_i && stall_nc) begin
+                        state_d = ABORT_TRANSACTION_NC;
+                    end else begin
+                    // should we not have hit on the TLB abort this transaction an retry later
                         state_d = ABORT_TRANSACTION;
+                    end
                 end
                 // otherwise we keep waiting on our grant
             end
@@ -175,12 +198,16 @@ module load_unit (
                             state_d = WAIT_GNT;
                         end else begin
                             // we got a grant so we can send the tag in the next cycle
-                            if (dtlb_hit_i) begin
+                            if (dtlb_hit_i && !stall_nc) begin
                                 // we got a grant and a hit on the DTLB so we can send the tag in the next cycle
                                 state_d = SEND_TAG;
                                 pop_ld_o = 1'b1;
-                            end else // we missed on the TLB -> wait for the translation
-                                state_d = ABORT_TRANSACTION;
+                            // translation valid but this is to NC and the WB is not yet empty.
+                            end else if (dtlb_hit_i && stall_nc) begin
+                                state_d = ABORT_TRANSACTION_NC;
+                            end else begin
+                                state_d = ABORT_TRANSACTION;// we missed on the TLB -> wait for the translation
+                            end
                         end
                     end else begin
                         // wait for the store buffer to train and the page offset to not match anymore
@@ -204,7 +231,6 @@ module load_unit (
                 // we've killed the current request so we can go back to idle
                 state_d = IDLE;
             end
-
         endcase
 
         // we got an exception
@@ -256,7 +282,6 @@ module load_unit (
         end else if (state_q == WAIT_TRANSLATION) begin
             valid_o = 1'b0;
         end
-
     end
 
 

--- a/src/scoreboard.sv
+++ b/src/scoreboard.sv
@@ -85,8 +85,10 @@ module scoreboard #(
 
   // output commit instruction directly
   always_comb begin : commit_ports
-    for (int unsigned i = 0; i < NR_COMMIT_PORTS; i++)
+    for (int unsigned i = 0; i < NR_COMMIT_PORTS; i++) begin
       commit_instr_o[i] = mem_q[commit_pointer_q[i]].sbe;
+      commit_instr_o[i].trans_id = commit_pointer_q[i];
+    end
   end
 
   // an instruction is ready for issue if we have place in the issue FIFO and it the decoder says it is valid

--- a/src/store_buffer.sv
+++ b/src/store_buffer.sv
@@ -21,6 +21,7 @@ module store_buffer (
     input logic          flush_i,         // if we flush we need to pause the transactions on the memory
                                           // otherwise we will run in a deadlock with the memory arbiter
     output logic         no_st_pending_o, // non-speculative queue is empty (e.g.: everything is committed to the memory hierarchy)
+    output logic         store_buffer_empty_o, // there is no store pending in neither the speculative unit or the non-speculative queue
 
     input  logic [11:0]  page_offset_i,         // check for the page offset (the last 12 bit if the current load matches them)
     output logic         page_offset_matches_o, // the above input page offset matches -> let the store buffer drain
@@ -65,7 +66,7 @@ module store_buffer (
     logic [$clog2(DEPTH_COMMIT)-1:0] commit_read_pointer_n,  commit_read_pointer_q;
     logic [$clog2(DEPTH_COMMIT)-1:0] commit_write_pointer_n, commit_write_pointer_q;
 
-
+    assign store_buffer_empty_o = (speculative_status_cnt_q == 0) & no_st_pending_o;
     // ----------------------------------------
     // Speculative Queue - Core Interface
     // ----------------------------------------

--- a/src/store_unit.sv
+++ b/src/store_unit.sv
@@ -19,6 +19,7 @@ module store_unit (
     input  logic                     rst_ni,  // Asynchronous reset active low
     input  logic                     flush_i,
     output logic                     no_st_pending_o,
+    output logic                     store_buffer_empty_o,
     // store unit input port
     input  logic                     valid_i,
     input  lsu_ctrl_t                lsu_ctrl_i,
@@ -217,6 +218,7 @@ module store_unit (
         .rst_ni,
         .flush_i,
         .no_st_pending_o,
+        .store_buffer_empty_o,
         .page_offset_i,
         .page_offset_matches_o,
         .commit_i,

--- a/tb/ariane_soc_pkg.sv
+++ b/tb/ariane_soc_pkg.sv
@@ -74,9 +74,9 @@ package ariane_soc;
     BTBEntries: 32,
     BHTEntries: 128,
     // idempotent region
-    NrNonIdempotentRules:  0,
+    NrNonIdempotentRules:  1,
     NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {64'b0},
+    NonIdempotentLength:   {DRAMBase},
     NrExecuteRegionRules:  3,
     ExecuteRegionAddrBase: {DRAMBase,   ROMBase,   DebugBase},
     ExecuteRegionLength:   {DRAMLength, ROMLength, DebugLength},


### PR DESCRIPTION
This is a tentative fix for #356. I would very much appreciate your feedback @jrrk as I don't have an isolated test case for it.

What the fix does is basically checking whether the write buffer is empty in case we are performing an uncached load. If the WB should not be empty the load is killed and retried once the WB gets empty.