### PR TITLE
address length: make configurable physical and virtual address length

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -303,42 +303,42 @@ package ariane_pkg;
     // all the necessary data structures
     // bp_resolve_t
     typedef struct packed {
-        logic        valid;           // prediction with all its values is valid
-        logic [63:0] pc;              // PC of predict or mis-predict
-        logic [63:0] target_address;  // target address at which to jump, or not
-        logic        is_mispredict;   // set if this was a mis-predict
-        logic        is_taken;        // branch is taken
-        cf_t         cf_type;         // Type of control flow change
+        logic                   valid;           // prediction with all its values is valid
+        logic [riscv::VLEN-1:0] pc;              // PC of predict or mis-predict
+        logic [riscv::VLEN-1:0] target_address;  // target address at which to jump, or not
+        logic                   is_mispredict;   // set if this was a mis-predict
+        logic                   is_taken;        // branch is taken
+        cf_t                    cf_type;         // Type of control flow change
     } bp_resolve_t;
 
     // branchpredict scoreboard entry
     // this is the struct which we will inject into the pipeline to guide the various
     // units towards the correct branch decision and resolve
     typedef struct packed {
-        cf_t         cf;              // type of control flow prediction
-        logic [63:0] predict_address; // target address at which to jump, or not
+        cf_t                    cf;              // type of control flow prediction
+        logic [riscv::VLEN-1:0] predict_address; // target address at which to jump, or not
     } branchpredict_sbe_t;
 
     typedef struct packed {
-        logic        valid;
-        logic [63:0] pc;             // update at PC
-        logic [63:0] target_address;
+        logic                   valid;
+        logic [riscv::VLEN-1:0] pc;             // update at PC
+        logic [riscv::VLEN-1:0] target_address;
     } btb_update_t;
 
     typedef struct packed {
-        logic        valid;
-        logic [63:0] target_address;
+        logic                   valid;
+        logic [riscv::VLEN-1:0] target_address;
     } btb_prediction_t;
 
     typedef struct packed {
-        logic        valid;
-        logic [63:0] ra;
+        logic                   valid;
+        logic [riscv::VLEN-1:0] ra;
     } ras_t;
 
     typedef struct packed {
-        logic        valid;
-        logic [63:0] pc;          // update at PC
-        logic        taken;
+        logic                   valid;
+        logic [riscv::VLEN-1:0] pc;          // update at PC
+        logic                   taken;
     } bht_update_t;
 
     typedef struct packed {
@@ -408,22 +408,22 @@ package ariane_pkg;
     localparam int unsigned ICACHE_LINE_WIDTH  = `CONFIG_L1I_CACHELINE_WIDTH;
     localparam int unsigned ICACHE_SET_ASSOC   = `CONFIG_L1I_ASSOCIATIVITY;
     localparam int unsigned ICACHE_INDEX_WIDTH = $clog2(`CONFIG_L1I_SIZE / ICACHE_SET_ASSOC);
-    localparam int unsigned ICACHE_TAG_WIDTH   = 56 - ICACHE_INDEX_WIDTH;
+    localparam int unsigned ICACHE_TAG_WIDTH   = riscv::PLEN - ICACHE_INDEX_WIDTH;
     // D$
     localparam int unsigned DCACHE_LINE_WIDTH  = `CONFIG_L1D_CACHELINE_WIDTH;
     localparam int unsigned DCACHE_SET_ASSOC   = `CONFIG_L1D_ASSOCIATIVITY;
     localparam int unsigned DCACHE_INDEX_WIDTH = $clog2(`CONFIG_L1D_SIZE / DCACHE_SET_ASSOC);
-    localparam int unsigned DCACHE_TAG_WIDTH   = 56 - DCACHE_INDEX_WIDTH;
+    localparam int unsigned DCACHE_TAG_WIDTH   = riscv::PLEN - DCACHE_INDEX_WIDTH;
 `else
     // align to openpiton for the time being (this should be more configurable in the future)
      // I$
     localparam int unsigned ICACHE_INDEX_WIDTH = 12;  // in bit
-    localparam int unsigned ICACHE_TAG_WIDTH   = 44;  // in bit
+    localparam int unsigned ICACHE_TAG_WIDTH   = riscv::PLEN-ICACHE_INDEX_WIDTH;  // in bit
     localparam int unsigned ICACHE_LINE_WIDTH  = 128; // in bit
     localparam int unsigned ICACHE_SET_ASSOC   = 4;
     // D$
     localparam int unsigned DCACHE_INDEX_WIDTH = 12;  // in bit
-    localparam int unsigned DCACHE_TAG_WIDTH   = 44;  // in bit
+    localparam int unsigned DCACHE_TAG_WIDTH   = riscv::PLEN-ICACHE_INDEX_WIDTH;  // in bit
     localparam int unsigned DCACHE_LINE_WIDTH  = 128; // in bit
     localparam int unsigned DCACHE_SET_ASSOC   = 8;
 `endif
@@ -562,7 +562,7 @@ package ariane_pkg;
 
     typedef struct packed {
         logic                     valid;
-        logic [63:0]              vaddr;
+        logic [riscv::VLEN-1:0]     vaddr;
         logic [63:0]              data;
         logic [7:0]               be;
         fu_t                      fu;
@@ -575,17 +575,17 @@ package ariane_pkg;
     // ---------------
     // store the decompressed instruction
     typedef struct packed {
-        logic [63:0]           address;        // the address of the instructions from below
-        logic [31:0]           instruction;    // instruction word
-        branchpredict_sbe_t    branch_predict; // this field contains branch prediction information regarding the forward branch path
-        exception_t            ex;             // this field contains exceptions which might have happened earlier, e.g.: fetch exceptions
+        logic [riscv::VLEN-1:0] address;        // the address of the instructions from below
+        logic [31:0]            instruction;    // instruction word
+        branchpredict_sbe_t     branch_predict; // this field contains branch prediction information regarding the forward branch path
+        exception_t             ex;             // this field contains exceptions which might have happened earlier, e.g.: fetch exceptions
     } fetch_entry_t;
 
     // ---------------
     // ID/EX/WB Stage
     // ---------------
     typedef struct packed {
-        logic [63:0]              pc;            // PC of instruction
+        logic [riscv::VLEN-1:0]   pc;            // PC of instruction
         logic [TRANS_ID_BITS-1:0] trans_id;      // this can potentially be simplified, we could index the scoreboard entry
                                                  // with the transaction id in any case make the width more generic
         fu_t                      fu;            // functional unit to use
@@ -649,13 +649,13 @@ package ariane_pkg;
     // I$ address translation requests
     typedef struct packed {
         logic                     fetch_valid;     // address translation valid
-        logic [63:0]              fetch_paddr;     // physical address in
+        logic [riscv::PLEN-1:0]   fetch_paddr;     // physical address in
         exception_t               fetch_exception; // exception occurred during fetch
     } icache_areq_i_t;
 
     typedef struct packed {
         logic                     fetch_req;       // address translation request
-        logic [63:0]              fetch_vaddr;     // virtual address out
+        logic [riscv::VLEN-1:0]   fetch_vaddr;     // virtual address out
     } icache_areq_o_t;
 
     // I$ data requests
@@ -663,14 +663,14 @@ package ariane_pkg;
         logic                     req;                    // we request a new word
         logic                     kill_s1;                // kill the current request
         logic                     kill_s2;                // kill the last request
-        logic [63:0]              vaddr;                  // 1st cycle: 12 bit index is taken for lookup
+        logic [riscv::VLEN-1:0]   vaddr;                  // 1st cycle: 12 bit index is taken for lookup
     } icache_dreq_i_t;
 
     typedef struct packed {
         logic                     ready;                  // icache is ready
         logic                     valid;                  // signals a valid read
         logic [FETCH_WIDTH-1:0]   data;                   // 2+ cycle out: tag
-        logic [63:0]              vaddr;                  // virtual address out
+        logic [riscv::VLEN-1:0]   vaddr;                  // virtual address out
         exception_t               ex;                     // we've encountered an exception
     } icache_dreq_o_t;
 
@@ -721,16 +721,16 @@ package ariane_pkg;
     // ----------------------
     // Immediate functions
     // ----------------------
-    function automatic logic [63:0] uj_imm (logic [31:0] instruction_i);
-        return { {44 {instruction_i[31]}}, instruction_i[19:12], instruction_i[20], instruction_i[30:21], 1'b0 };
+    function automatic logic [riscv::VLEN-1:0] uj_imm (logic [31:0] instruction_i);
+        return { {44+riscv::VLEN-64 {instruction_i[31]}}, instruction_i[19:12], instruction_i[20], instruction_i[30:21], 1'b0 };
     endfunction
 
-    function automatic logic [63:0] i_imm (logic [31:0] instruction_i);
-        return { {52 {instruction_i[31]}}, instruction_i[31:20] };
+    function automatic logic [riscv::VLEN-1:0] i_imm (logic [31:0] instruction_i);
+        return { {52+riscv::VLEN-64 {instruction_i[31]}}, instruction_i[31:20] };
     endfunction
 
-    function automatic logic [63:0] sb_imm (logic [31:0] instruction_i);
-        return { {51 {instruction_i[31]}}, instruction_i[31], instruction_i[7], instruction_i[30:25], instruction_i[11:8], 1'b0 };
+    function automatic logic [riscv::VLEN-1:0] sb_imm (logic [31:0] instruction_i);
+        return { {51+riscv::VLEN-64 {instruction_i[31]}}, instruction_i[31], instruction_i[7], instruction_i[30:25], instruction_i[11:8], 1'b0 };
     endfunction
 
     // ----------------------

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -562,7 +562,8 @@ package ariane_pkg;
 
     typedef struct packed {
         logic                     valid;
-        logic [riscv::VLEN-1:0]     vaddr;
+        logic [riscv::VLEN-1:0]   vaddr;
+        logic                     overflow;
         logic [63:0]              data;
         logic [7:0]               be;
         fu_t                      fu;

--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -16,6 +16,15 @@
  */
 package riscv;
 
+    // ----------------------
+    // Address length
+    // ----------------------
+    // PLEN configures physical address length
+    // VLEN configures virtual address length
+    // Warning: When using STD_CACHE, configuration must be PLEN=56 and VLEN=64
+    localparam PLEN = 56;
+    localparam VLEN = 64;
+
     // --------------------
     // Privilege Spec
     // --------------------
@@ -261,7 +270,7 @@ package riscv;
     // memory management, pte
     typedef struct packed {
         logic [9:0]  reserved;
-        logic [43:0] ppn;
+        logic [riscv::PLEN-12-1:0] ppn;
         logic [1:0]  rsw;
         logic d;
         logic a;

--- a/include/wt_cache_pkg.sv
+++ b/include/wt_cache_pkg.sv
@@ -123,7 +123,7 @@ package wt_cache_pkg;
   // icache interface
   typedef struct packed {
     logic [$clog2(ariane_pkg::ICACHE_SET_ASSOC)-1:0] way;         // way to replace
-    logic [63:0]                                     paddr;       // physical address
+    logic [riscv::PLEN-1:0]                          paddr;       // physical address
     logic                                            nc;          // noncacheable
     logic [CACHE_ID_WIDTH-1:0]                       tid;         // threadi id (used as transaction id in Ariane)
   } icache_req_t;
@@ -140,7 +140,7 @@ package wt_cache_pkg;
     dcache_out_t                                     rtype;       // see definitions above
     logic [2:0]                                      size;        // transaction size: 000=Byte 001=2Byte; 010=4Byte; 011=8Byte; 111=Cache line (16/32Byte)
     logic [L1D_WAY_WIDTH-1:0]                        way;         // way to replace
-    logic [63:0]                                     paddr;       // physical address
+    logic [riscv::PLEN-1:0]                          paddr;       // physical address
     logic [63:0]                                     data;        // word width of processor (no block stores at the moment)
     logic                                            nc;          // noncacheable
     logic [CACHE_ID_WIDTH-1:0]                       tid;         // threadi id (used as transaction id in Ariane)
@@ -341,11 +341,11 @@ package wt_cache_pkg;
   // 010: word
   // 011: dword
   // 111: DCACHE line
-  function automatic logic [63:0] paddrSizeAlign(
-    input logic [63:0] paddr,
+  function automatic logic [riscv::PLEN-1:0] paddrSizeAlign(
+    input logic [riscv::PLEN-1:0] paddr,
     input logic [2:0]  size
   );
-    logic [63:0] out;
+    logic [riscv::PLEN-1:0] out;
     out = paddr;
     unique case (size)
       3'b001: out[0:0]                     = '0;

--- a/src/amo_buffer.sv
+++ b/src/amo_buffer.sv
@@ -22,7 +22,7 @@ module amo_buffer (
     input  logic             valid_i,            // AMO is valid
     output logic             ready_o,            // AMO unit is ready
     input  ariane_pkg::amo_t amo_op_i,           // AMO Operation
-    input  logic [63:0]      paddr_i,            // physical address of store which needs to be placed in the queue
+    input  logic [riscv::PLEN-1:0]      paddr_i,            // physical address of store which needs to be placed in the queue
     input  logic [63:0]      data_i,             // data which is placed in the queue
     input  logic [1:0]       data_size_i,        // type of request we are making (e.g.: bytes to write)
     // D$
@@ -37,7 +37,7 @@ module amo_buffer (
 
     typedef struct packed {
         ariane_pkg::amo_t        op;
-        logic [63:0] paddr;
+        logic [riscv::PLEN-1:0] paddr;
         logic [63:0] data;
         logic [1:0]  size;
     } amo_op_t ;
@@ -48,7 +48,7 @@ module amo_buffer (
     assign amo_req_o.req = no_st_pending_i & amo_valid_commit_i & amo_valid;
     assign amo_req_o.amo_op = amo_data_out.op;
     assign amo_req_o.size = amo_data_out.size;
-    assign amo_req_o.operand_a = amo_data_out.paddr;
+    assign amo_req_o.operand_a = {{64-riscv::PLEN{1'b0}}, amo_data_out.paddr};
     assign amo_req_o.operand_b = amo_data_out.data;
 
     assign amo_data_in.op = amo_op_i;

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -47,15 +47,15 @@ module ariane #(
   riscv::priv_lvl_t           priv_lvl;
   exception_t                 ex_commit; // exception from commit stage
   bp_resolve_t                resolved_branch;
-  logic [63:0]                pc_commit;
+  logic [riscv::VLEN-1:0]     pc_commit;
   logic                       eret;
   logic [NR_COMMIT_PORTS-1:0] commit_ack;
 
   // --------------
   // PCGEN <-> CSR
   // --------------
-  logic [63:0]              trap_vector_base_commit_pcgen;
-  logic [63:0]              epc_commit_pcgen;
+  logic [riscv::VLEN-1:0]     trap_vector_base_commit_pcgen;
+  logic [riscv::VLEN-1:0]     epc_commit_pcgen;
   // --------------
   // IF <-> ID
   // --------------
@@ -75,7 +75,7 @@ module ariane #(
   // ISSUE <-> EX
   // --------------
   fu_data_t                 fu_data_id_ex;
-  logic [63:0]              pc_id_ex;
+  logic [riscv::VLEN-1:0]   pc_id_ex;
   logic                     is_compressed_instr_id_ex;
   // fixed latency units
   logic                     flu_ready_ex_id;
@@ -463,6 +463,7 @@ module ariane #(
     .halt_csr_o             ( halt_csr_ctrl                 ),
     .commit_instr_i         ( commit_instr_id_commit        ),
     .commit_ack_i           ( commit_ack                    ),
+    .boot_addr_i            ( boot_addr_i                   ),
     .ex_i                   ( ex_commit                     ),
     .csr_op_i               ( csr_op_commit_csr             ),
     .csr_write_fflags_i     ( csr_write_fflags_commit_cs    ),
@@ -506,7 +507,6 @@ module ariane #(
     .time_irq_i,
     .*
   );
-
   // ------------------------
   // Performance Counters
   // ------------------------
@@ -662,8 +662,8 @@ module ariane #(
   localparam PC_QUEUE_DEPTH = 16;
 
   logic        piton_pc_vld;
-  logic [63:0] piton_pc;
-  logic [NR_COMMIT_PORTS-1:0][63:0] pc_data;
+  logic [riscv::VLEN-1:0] piton_pc;
+  logic [NR_COMMIT_PORTS-1:0][riscv::VLEN-1:0] pc_data;
   logic [NR_COMMIT_PORTS-1:0] pc_pop, pc_empty;
 
   for (genvar i = 0; i < NR_COMMIT_PORTS; i++) begin : gen_pc_fifo

--- a/src/branch_unit.sv
+++ b/src/branch_unit.sv
@@ -49,7 +49,7 @@ module branch_unit (
         resolved_branch_o.cf_type        = branch_predict_i.cf;
         // calculate next PC, depending on whether the instruction is compressed or not this may be different
         // TODO(zarubaf): We already calculate this a couple of times, maybe re-use?
-        next_pc                          = pc_i + ((is_compressed_instr_i) ? {{riscv::VLEN-2{1'b0}}, 2'b10} : {{riscv::VLEN-3{1'b0}}, 3'b100});
+        next_pc                          = pc_i + ((is_compressed_instr_i) ? {{riscv::VLEN-2{1'b0}}, 2'h2} : {{riscv::VLEN-3{1'b0}}, 3'h4});
         // calculate target address simple 64 bit addition
         target_address                   = $unsigned($signed(jump_base) + $signed(fu_data_i.imm[riscv::VLEN-1:0]));
         // on a JALR we are supposed to reset the LSB to 0 (according to the specification)

--- a/src/branch_unit.sv
+++ b/src/branch_unit.sv
@@ -87,7 +87,7 @@ module branch_unit (
     always_comb begin : exception_handling
         branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
         branch_exception_o.valid = 1'b0;
-        branch_exception_o.tval  = {{64-riscv::VLEN{1'b0}}, pc_i};
+        branch_exception_o.tval  = {{64-riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
         // only throw exception if this is indeed a branch
         if (branch_valid_i && target_address[0] != 1'b0) branch_exception_o.valid = 1'b1;
     end

--- a/src/branch_unit.sv
+++ b/src/branch_unit.sv
@@ -17,12 +17,12 @@ module branch_unit (
     input  logic                      rst_ni,
     input  logic                      debug_mode_i,
     input  ariane_pkg::fu_data_t      fu_data_i,
-    input  logic [63:0]               pc_i,                   // PC of instruction
+    input  logic [riscv::VLEN-1:0]    pc_i,                   // PC of instruction
     input  logic                      is_compressed_instr_i,
     input  logic                      fu_valid_i,             // any functional unit is valid, check that there is no accidental mis-predict
     input  logic                      branch_valid_i,
     input  logic                      branch_comp_res_i,      // branch comparison result from ALU
-    output logic [63:0]               branch_result_o,
+    output logic [riscv::VLEN-1:0]    branch_result_o,
 
     input  ariane_pkg::branchpredict_sbe_t        branch_predict_i,       // this is the address we predicted
     output ariane_pkg::bp_resolve_t               resolved_branch_o,      // this is the actual address we are targeting
@@ -30,28 +30,28 @@ module branch_unit (
                                                               // accept new entries to the scoreboard
     output ariane_pkg::exception_t    branch_exception_o      // branch exception out
 );
-    logic [63:0] target_address;
-    logic [63:0] next_pc;
+    logic [riscv::VLEN-1:0] target_address;
+    logic [riscv::VLEN-1:0] next_pc;
 
    // here we handle the various possibilities of mis-predicts
     always_comb begin : mispredict_handler
         // set the jump base, for JALR we need to look at the register, for all other control flow instructions we can take the current PC
-        automatic logic [63:0] jump_base;
+        automatic logic [riscv::VLEN-1:0] jump_base;
         // TODO(zarubaf): The ALU can be used to calculate the branch target
-        jump_base = (fu_data_i.operator == ariane_pkg::JALR) ? fu_data_i.operand_a : pc_i;
+        jump_base = (fu_data_i.operator == ariane_pkg::JALR) ? fu_data_i.operand_a[riscv::VLEN-1:0] : pc_i;
 
-        target_address                   = 64'b0;
+        target_address                   = {riscv::VLEN{1'b0}};
         resolve_branch_o                 = 1'b0;
-        resolved_branch_o.target_address = 64'b0;
+        resolved_branch_o.target_address = {riscv::VLEN{1'b0}};
         resolved_branch_o.is_taken       = 1'b0;
         resolved_branch_o.valid          = branch_valid_i;
         resolved_branch_o.is_mispredict  = 1'b0;
         resolved_branch_o.cf_type        = branch_predict_i.cf;
         // calculate next PC, depending on whether the instruction is compressed or not this may be different
         // TODO(zarubaf): We already calculate this a couple of times, maybe re-use?
-        next_pc                          = pc_i + ((is_compressed_instr_i) ? 64'h2 : 64'h4);
+        next_pc                          = pc_i + ((is_compressed_instr_i) ? {{riscv::VLEN-2{1'b0}}, 2'b10} : {{riscv::VLEN-3{1'b0}}, 3'b100});
         // calculate target address simple 64 bit addition
-        target_address                   = $unsigned($signed(jump_base) + $signed(fu_data_i.imm));
+        target_address                   = $unsigned($signed(jump_base) + $signed(fu_data_i.imm[riscv::VLEN-1:0]));
         // on a JALR we are supposed to reset the LSB to 0 (according to the specification)
         if (fu_data_i.operator == ariane_pkg::JALR) target_address[0] = 1'b0;
         // we need to put the branch target address into rd, this is the result of this unit
@@ -87,7 +87,7 @@ module branch_unit (
     always_comb begin : exception_handling
         branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
         branch_exception_o.valid = 1'b0;
-        branch_exception_o.tval  = pc_i;
+        branch_exception_o.tval  = {{64-riscv::VLEN{1'b0}}, pc_i};
         // only throw exception if this is indeed a branch
         if (branch_valid_i && target_address[0] != 1'b0) branch_exception_o.valid = 1'b1;
     end

--- a/src/cache_subsystem/wt_axi_adapter.sv
+++ b/src/cache_subsystem/wt_axi_adapter.sv
@@ -122,7 +122,7 @@ module wt_axi_adapter #(
     // write channel
     axi_wr_id_in = arb_idx;
     axi_wr_data  = dcache_data.data;
-    axi_wr_addr  = dcache_data.paddr;
+    axi_wr_addr  = {{64-riscv::PLEN{1'b0}}, dcache_data.paddr};
     axi_wr_size  = dcache_data.size[1:0];
     axi_wr_req   = 1'b0;
     axi_wr_blen  = '0;// single word writes
@@ -140,13 +140,13 @@ module wt_axi_adapter #(
 
     // arbiter mux
     if (arb_idx) begin
-      axi_rd_addr  = dcache_data.paddr;
+      axi_rd_addr  = {{64-riscv::PLEN{1'b0}}, dcache_data.paddr};
       axi_rd_size  = dcache_data.size[1:0];
       if (dcache_data.size[2]) begin
         axi_rd_blen = ariane_pkg::DCACHE_LINE_WIDTH/64-1;
       end
     end else begin
-      axi_rd_addr  = icache_data.paddr;
+      axi_rd_addr  = {{64-riscv::PLEN{1'b0}}, icache_data.paddr};
       axi_rd_size  = 2'b11;// always request 64bit words in case of ifill
       if (!icache_data.nc) begin
         axi_rd_blen = ariane_pkg::ICACHE_LINE_WIDTH/64-1;

--- a/src/cache_subsystem/wt_dcache.sv
+++ b/src/cache_subsystem/wt_dcache.sv
@@ -76,7 +76,7 @@ module wt_dcache #(
   logic [NumPorts-1:0]                          miss_nc;
   logic [NumPorts-1:0]                          miss_we;
   logic [NumPorts-1:0][63:0]                    miss_wdata;
-  logic [NumPorts-1:0][63:0]                    miss_paddr;
+  logic [NumPorts-1:0][riscv::PLEN-1:0]         miss_paddr;
   logic [NumPorts-1:0][DCACHE_SET_ASSOC-1:0]    miss_vld_bits;
   logic [NumPorts-1:0][2:0]                     miss_size;
   logic [NumPorts-1:0][CACHE_ID_WIDTH-1:0]      miss_id;
@@ -97,7 +97,7 @@ module wt_dcache #(
   logic [DCACHE_SET_ASSOC-1:0]                  rd_hit_oh;
 
   // miss unit <-> wbuffer
-  logic [DCACHE_MAX_TX-1:0][63:0]               tx_paddr;
+  logic [DCACHE_MAX_TX-1:0][riscv::PLEN-1:0]    tx_paddr;
   logic [DCACHE_MAX_TX-1:0]                     tx_vld;
 
   // wbuffer <-> memory

--- a/src/cache_subsystem/wt_dcache_ctrl.sv
+++ b/src/cache_subsystem/wt_dcache_ctrl.sv
@@ -31,7 +31,7 @@ module wt_dcache_ctrl #(
   output logic                            miss_we_o,       // unused (set to 0)
   output logic [63:0]                     miss_wdata_o,    // unused (set to 0)
   output logic [DCACHE_SET_ASSOC-1:0]     miss_vld_bits_o, // valid bits at the missed index
-  output logic [63:0]                     miss_paddr_o,
+  output logic [riscv::PLEN-1:0]          miss_paddr_o,
   output logic                            miss_nc_o,       // request to I/O space
   output logic [2:0]                      miss_size_o,     // 00: 1byte, 01: 2byte, 10: 4byte, 11: 8byte, 111: cacheline
   output logic [CACHE_ID_WIDTH-1:0]       miss_id_o,       // set to constant ID
@@ -84,7 +84,7 @@ module wt_dcache_ctrl #(
   assign miss_size_o           = (miss_nc_o) ? data_size_q : 3'b111;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
+  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{{64-DCACHE_TAG_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
 
 
   assign miss_we_o    = '0;

--- a/src/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/src/cache_subsystem/wt_dcache_wbuffer.sv
@@ -64,7 +64,7 @@ module wt_dcache_wbuffer #(
   output dcache_req_o_t                      req_port_o,
   // interface to miss handler
   input  logic                               miss_ack_i,
-  output logic [63:0]                        miss_paddr_o,
+  output logic [riscv::PLEN-1:0]             miss_paddr_o,
   output logic                               miss_req_o,
   output logic                               miss_we_o,       // always 1 here
   output logic [63:0]                        miss_wdata_o,
@@ -97,7 +97,7 @@ module wt_dcache_wbuffer #(
   output logic [7:0]                         wr_data_be_o,
   // to forwarding logic and miss unit
   output wbuffer_t  [DCACHE_WBUF_DEPTH-1:0]  wbuffer_data_o,
-  output logic [DCACHE_MAX_TX-1:0][63:0]     tx_paddr_o,      // used to check for address collisions with read operations
+  output logic [DCACHE_MAX_TX-1:0][riscv::PLEN-1:0]     tx_paddr_o,      // used to check for address collisions with read operations
   output logic [DCACHE_MAX_TX-1:0]           tx_vld_o
 );
 
@@ -114,7 +114,7 @@ module wt_dcache_wbuffer #(
 
   logic [2:0] bdirty_off;
   logic [7:0] tx_be;
-  logic [63:0] wr_paddr, rd_paddr;
+  logic [riscv::PLEN-1:0] wr_paddr, rd_paddr;
   logic [DCACHE_TAG_WIDTH-1:0] rd_tag_d, rd_tag_q;
   logic [DCACHE_SET_ASSOC-1:0] rd_hit_oh_d, rd_hit_oh_q;
   logic check_en_d, check_en_q, check_en_q1;
@@ -127,7 +127,7 @@ module wt_dcache_wbuffer #(
   logic wr_cl_vld_q, wr_cl_vld_d;
   logic [DCACHE_CL_IDX_WIDTH-1:0] wr_cl_idx_q, wr_cl_idx_d;
 
-  logic [63:0] debug_paddr [DCACHE_WBUF_DEPTH-1:0];
+  logic [riscv::PLEN-1:0] debug_paddr [DCACHE_WBUF_DEPTH-1:0];
 
   wbuffer_t wbuffer_check_mux, wbuffer_dirty_mux;
 
@@ -138,7 +138,7 @@ module wt_dcache_wbuffer #(
   assign miss_nc_o = nc_pending_q;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign addr_is_nc = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}}));
+  assign addr_is_nc = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}}));
 
   assign miss_we_o       = 1'b1;
   assign miss_vld_bits_o = '0;

--- a/src/cache_subsystem/wt_icache.sv
+++ b/src/cache_subsystem/wt_icache.sv
@@ -53,7 +53,7 @@ module wt_icache  #(
 
   // signals
   logic                                 cache_en_d, cache_en_q;       // cache is enabled
-  logic [63:0]                          vaddr_d, vaddr_q;
+  logic [riscv::VLEN-1:0]               vaddr_d, vaddr_q;
   logic                                 paddr_is_nc;                  // asserted if physical address is non-cacheable
   logic [ICACHE_SET_ASSOC-1:0]          cl_hit;                       // hit from tag compare
   logic                                 cache_rden;                   // triggers cache lookup
@@ -101,7 +101,7 @@ module wt_icache  #(
   assign cl_tag_d  = (areq_i.fetch_valid) ? areq_i.fetch_paddr[ICACHE_TAG_WIDTH+ICACHE_INDEX_WIDTH-1:ICACHE_INDEX_WIDTH] : cl_tag_q;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign paddr_is_nc = (~cache_en_q) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
+  assign paddr_is_nc = (~cache_en_q) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{64-ICACHE_TAG_WIDTH{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
 
   // pass exception through
   assign dreq_o.ex = areq_i.fetch_exception;

--- a/src/commit_stage.sv
+++ b/src/commit_stage.sv
@@ -35,7 +35,7 @@ module commit_stage #(
     // Atomic memory operations
     input  amo_resp_t                               amo_resp_i,         // result of AMO operation
     // to CSR file and PC Gen (because on certain CSR instructions we'll need to flush the whole pipeline)
-    output logic [63:0]                             pc_o,
+    output logic [riscv::VLEN-1:0]                  pc_o,
     // to/from CSR file
     output fu_op                                    csr_op_o,           // decoded CSR operation
     output logic [63:0]                             csr_wdata_o,        // data to write to CSR

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -606,7 +606,7 @@ module csr_regfile #(
                 // set cause
                 scause_d       = ex_i.cause;
                 // set epc
-                sepc_d         = {{64-riscv::VLEN{1'b0}},pc_i};
+                sepc_d         = {{64-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 // set mtval or stval
                 stval_d        = (ariane_pkg::ZERO_TVAL
                                   && (ex_i.cause inside {
@@ -625,7 +625,7 @@ module csr_regfile #(
                 mstatus_d.mpp  = priv_lvl_q;
                 mcause_d       = ex_i.cause;
                 // set epc
-                mepc_d         = {{64-riscv::VLEN{1'b0}},pc_i};
+                mepc_d         = {{64-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 // set mtval or stval
                 mtval_d        = (ariane_pkg::ZERO_TVAL
                                   && (ex_i.cause inside {
@@ -673,14 +673,14 @@ module csr_regfile #(
                     default:;
                 endcase
                 // save PC of next this instruction e.g.: the next one to be executed
-                dpc_d = {{64-riscv::VLEN{1'b0}},pc_i};
+                dpc_d = {{64-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 dcsr_d.cause = dm::CauseBreakpoint;
             end
 
             // we've got a debug request
             if (ex_i.valid && ex_i.cause == riscv::DEBUG_REQUEST) begin
                 // save the PC
-                dpc_d = {{64-riscv::VLEN{1'b0}},pc_i};
+                dpc_d = {{64-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 // enter debug mode
                 debug_mode_d = 1'b1;
                 // jump to the base address
@@ -694,7 +694,7 @@ module csr_regfile #(
                 // valid CTRL flow change
                 if (commit_instr_i[0].fu == CTRL_FLOW) begin
                     // we saved the correct target address during execute
-                    dpc_d = {{64-riscv::VLEN{1'b0}}, commit_instr_i[0].bp.predict_address};
+                    dpc_d = {{64-riscv::VLEN{commit_instr_i[0].bp.predict_address[riscv::VLEN-1]}}, commit_instr_i[0].bp.predict_address};
                 // exception valid
                 end else if (ex_i.valid) begin
                     dpc_d = {{64-riscv::VLEN{1'b0}},trap_vector_base_o};
@@ -703,7 +703,7 @@ module csr_regfile #(
                     dpc_d = {{64-riscv::VLEN{1'b0}},epc_o};
                 // consecutive PC
                 end else begin
-                    dpc_d = {{64-riscv::VLEN{1'b0}}, commit_instr_i[0].pc + (commit_instr_i[0].is_compressed ? 'h2 : 'h4)};
+                    dpc_d = {{64-riscv::VLEN{commit_instr_i[0].pc[riscv::VLEN-1]}}, commit_instr_i[0].pc + (commit_instr_i[0].is_compressed ? 'h2 : 'h4)};
                 end
                 debug_mode_d = 1'b1;
                 set_debug_pc_o = 1'b1;

--- a/src/decoder.sv
+++ b/src/decoder.sv
@@ -22,7 +22,7 @@ import ariane_pkg::*;
 
 module decoder (
     input  logic               debug_req_i,             // external debug request
-    input  logic [63:0]        pc_i,                    // PC from IF
+    input  logic [riscv::VLEN-1:0] pc_i,                // PC from IF
     input  logic               is_compressed_i,         // is a compressed instruction
     input  logic [15:0]        compressed_instr_i,      // compressed form of instruction
     input  logic               is_illegal_i,            // illegal compressed instruction
@@ -1006,11 +1006,11 @@ module decoder (
     // Sign extend immediate
     // --------------------------------
     always_comb begin : sign_extend
-        imm_i_type  = i_imm(instruction_i);
+        imm_i_type  = { {52 {instruction_i[31]}}, instruction_i[31:20] };
         imm_s_type  = { {52 {instruction_i[31]}}, instruction_i[31:25], instruction_i[11:7] };
-        imm_sb_type = sb_imm(instruction_i);
+        imm_sb_type = { {51 {instruction_i[31]}}, instruction_i[31], instruction_i[7], instruction_i[30:25], instruction_i[11:8], 1'b0 };
         imm_u_type  = { {32 {instruction_i[31]}}, instruction_i[31:12], 12'b0 }; // JAL, AUIPC, sign extended to 64 bit
-        imm_uj_type = uj_imm(instruction_i);
+        imm_uj_type = { {44 {instruction_i[31]}}, instruction_i[19:12], instruction_i[20], instruction_i[30:21], 1'b0 };
         imm_bi_type = { {59{instruction_i[24]}}, instruction_i[24:20] };
 
         // NOIMM, IIMM, SIMM, BIMM, UIMM, JIMM, RS3

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -24,7 +24,7 @@ module ex_stage #(
     input  logic                                   debug_mode_i,
 
     input  fu_data_t                               fu_data_i,
-    input  logic [63:0]                            pc_i,                  // PC of current instruction
+    input  logic [riscv::VLEN-1:0]                 pc_i,                  // PC of current instruction
     input  logic                                   is_compressed_instr_i, // we need to know if this was a compressed instruction
                                                                           // in order to calculate the next PC on a mis-predict
     // Fixed latency unit(s)
@@ -122,7 +122,8 @@ module ex_stage #(
 
     // from ALU to branch unit
     logic alu_branch_res; // branch comparison result
-    logic [63:0] alu_result, branch_result, csr_result, mult_result;
+    logic [63:0] alu_result, csr_result, mult_result;
+    logic [riscv::VLEN-1:0] branch_result;
     logic csr_ready, mult_ready;
     logic [TRANS_ID_BITS-1:0] mult_trans_id;
     logic mult_valid;
@@ -179,7 +180,7 @@ module ex_stage #(
     // result MUX
     always_comb begin
         // Branch result as default case
-        flu_result_o = branch_result;
+        flu_result_o = {{64-riscv::VLEN{1'b0}}, branch_result};
         flu_trans_id_o = fu_data_i.trans_id;
         // ALU result
         if (alu_valid_i) begin

--- a/src/frontend/bht.sv
+++ b/src/frontend/bht.sv
@@ -21,7 +21,7 @@ module bht #(
     input  logic                        rst_ni,
     input  logic                        flush_i,
     input  logic                        debug_mode_i,
-    input  logic [63:0]                 vpc_i,
+    input  logic [riscv::VLEN-1:0]      vpc_i,
     input  ariane_pkg::bht_update_t     bht_update_i,
     // we potentially need INSTR_PER_FETCH predictions/cycle
     output ariane_pkg::bht_prediction_t [ariane_pkg::INSTR_PER_FETCH-1:0] bht_prediction_o

--- a/src/frontend/btb.sv
+++ b/src/frontend/btb.sv
@@ -22,7 +22,7 @@ module btb #(
     input  logic                        flush_i,         // flush the btb
     input  logic                        debug_mode_i,
 
-    input  logic [63:0]                 vpc_i,           // virtual PC from IF stage
+    input  logic [riscv::VLEN-1:0]      vpc_i,           // virtual PC from IF stage
     input  ariane_pkg::btb_update_t     btb_update_i,    // update btb with this information
     output ariane_pkg::btb_prediction_t [ariane_pkg::INSTR_PER_FETCH-1:0] btb_prediction_o // prediction from btb
 );

--- a/src/frontend/instr_scan.sv
+++ b/src/frontend/instr_scan.sv
@@ -22,14 +22,14 @@ module instr_scan (
     output logic        rvi_branch_o,
     output logic        rvi_jalr_o,
     output logic        rvi_jump_o,
-    output logic [63:0] rvi_imm_o,
+    output logic [riscv::VLEN-1:0] rvi_imm_o,
     output logic        rvc_branch_o,
     output logic        rvc_jump_o,
     output logic        rvc_jr_o,
     output logic        rvc_return_o,
     output logic        rvc_jalr_o,
     output logic        rvc_call_o,
-    output logic [63:0] rvc_imm_o
+    output logic [riscv::VLEN-1:0] rvc_imm_o
 );
     logic is_rvc;
     assign is_rvc     = (instr_i[1:0] != 2'b11);
@@ -64,6 +64,6 @@ module instr_scan (
     assign rvc_return_o = ((instr_i[11:7] == 5'd1) | (instr_i[11:7] == 5'd5))  & rvc_jr_o ;
 
     // differentiates between JAL and BRANCH opcode, JALR comes from BHT
-    assign rvc_imm_o    = (instr_i[14]) ? {{56{instr_i[12]}}, instr_i[6:5], instr_i[2], instr_i[11:10], instr_i[4:3], 1'b0}
-                                       : {{53{instr_i[12]}}, instr_i[8], instr_i[10:9], instr_i[6], instr_i[7], instr_i[2], instr_i[11], instr_i[5:3], 1'b0};
+    assign rvc_imm_o    = (instr_i[14]) ? {{56+riscv::VLEN-64{instr_i[12]}}, instr_i[6:5], instr_i[2], instr_i[11:10], instr_i[4:3], 1'b0}
+                                       : {{53+riscv::VLEN-64{instr_i[12]}}, instr_i[8], instr_i[10:9], instr_i[6], instr_i[7], instr_i[2], instr_i[11], instr_i[5:3], 1'b0};
 endmodule

--- a/src/frontend/ras.sv
+++ b/src/frontend/ras.sv
@@ -22,7 +22,7 @@ module ras #(
     input  logic             flush_i,
     input  logic             push_i,
     input  logic             pop_i,
-    input  logic [63:0]      data_i,
+    input  logic [riscv::VLEN-1:0]      data_i,
     output ariane_pkg::ras_t data_o
 );
 

--- a/src/instr_realign.sv
+++ b/src/instr_realign.sv
@@ -27,10 +27,10 @@ module instr_realign (
     input  logic                              flush_i,
     input  logic                              valid_i,
     output logic                              serving_unaligned_o, // we have an unaligned instruction in [0]
-    input  logic [63:0]                       address_i,
+    input  logic [riscv::VLEN-1:0]            address_i,
     input  logic [FETCH_WIDTH-1:0]            data_i,
     output logic [INSTR_PER_FETCH-1:0]        valid_o,
-    output logic [INSTR_PER_FETCH-1:0][63:0]  addr_o,
+    output logic [INSTR_PER_FETCH-1:0][riscv::VLEN-1:0]  addr_o,
     output logic [INSTR_PER_FETCH-1:0][31:0]  instr_o
 );
     // as a maximum we support a fetch width of 64-bit, hence there can be 4 compressed instructions
@@ -46,7 +46,7 @@ module instr_realign (
     // the last instruction was unaligned
     logic        unaligned_d,         unaligned_q;
     // register to save the unaligned address
-    logic [63:0] unaligned_address_d, unaligned_address_q;
+    logic [riscv::VLEN-1:0] unaligned_address_d, unaligned_address_q;
     // we have an unaligned instruction
     assign serving_unaligned_o = unaligned_q;
 
@@ -54,7 +54,7 @@ module instr_realign (
     if (FETCH_WIDTH == 32) begin : realign_bp_32
         always_comb begin : re_align
             unaligned_d = unaligned_q;
-            unaligned_address_d = {address_i[63:2], 2'b10};
+            unaligned_address_d = {address_i[riscv::VLEN-1:2], 2'b10};
             unaligned_instr_d = data_i[31:16];
 
             valid_o[0] = valid_i;
@@ -63,7 +63,7 @@ module instr_realign (
 
             valid_o[1] = 1'b0;
             instr_o[1] = '0;
-            addr_o[1]  = {address_i[63:2], 2'b10};
+            addr_o[1]  = {address_i[riscv::VLEN-1:2], 2'b10};
 
             // this instruction is compressed or the last instruction was unaligned
             if (instr_is_compressed[0] || unaligned_q) begin
@@ -81,7 +81,7 @@ module instr_realign (
                     // save the upper bits for next cycle
                     unaligned_d = 1'b1;
                     unaligned_instr_d = data_i[31:16];
-                    unaligned_address_d = {address_i[63:2], 2'b10};
+                    unaligned_address_d = {address_i[riscv::VLEN-1:2], 2'b10};
                 end
             end // else -> normal fetch
 
@@ -92,7 +92,7 @@ module instr_realign (
                 if (!instr_is_compressed[0]) begin
                     valid_o = '0;
                     unaligned_d = 1'b1;
-                    unaligned_address_d = {address_i[63:2], 2'b10};
+                    unaligned_address_d = {address_i[riscv::VLEN-1:2], 2'b10};
                     unaligned_instr_d = data_i[15:0];
                 // the instruction isn't compressed but only the lower is ready
                 end else begin
@@ -117,13 +117,13 @@ module instr_realign (
             addr_o[0]  = address_i;
 
             instr_o[1] = '0;
-            addr_o[1]  = {address_i[63:3], 3'b010};
+            addr_o[1]  = {address_i[riscv::VLEN-1:3], 3'b010};
 
             instr_o[2] = {16'b0, data_i[47:32]};
-            addr_o[2]  = {address_i[63:3], 3'b100};
+            addr_o[2]  = {address_i[riscv::VLEN-1:3], 3'b100};
 
             instr_o[3] = {16'b0, data_i[63:48]};
-            addr_o[3]  = {address_i[63:3], 3'b110};
+            addr_o[3]  = {address_i[riscv::VLEN-1:3], 3'b110};
 
             // last instruction was unaligned
             if (unaligned_q) begin
@@ -159,7 +159,7 @@ module instr_realign (
                 end else begin
                     instr_o[1] = data_i[47:16];
                     valid_o[1] = valid_i;
-                    addr_o[2] = {address_i[63:3], 3'b110};
+                    addr_o[2] = {address_i[riscv::VLEN-1:3], 3'b110};
                     if (instr_is_compressed[2]) begin
                         unaligned_d = 1'b0;
                         instr_o[2] = {16'b0, data_i[63:48]};
@@ -198,7 +198,7 @@ module instr_realign (
                 end else begin
                     instr_o[1] = data_i[47:16];
                     valid_o[1] = valid_i;
-                    addr_o[2] = {address_i[63:3], 3'b110};
+                    addr_o[2] = {address_i[riscv::VLEN-1:3], 3'b110};
                     if (instr_is_compressed[3]) begin
                         instr_o[2] = data_i[63:48];
                         valid_o[2] = valid_i;
@@ -216,12 +216,12 @@ module instr_realign (
             // | * | C | C |   I   |
             // | * |   I   |   I   |
             end else begin
-                addr_o[1] = {address_i[63:3], 3'b100};
+                addr_o[1] = {address_i[riscv::VLEN-1:3], 3'b100};
 
                 if (instr_is_compressed[2]) begin
                     instr_o[1] = {16'b0, data_i[47:32]};
                     valid_o[1] = valid_i;
-                    addr_o[2] = {address_i[63:3], 3'b110};
+                    addr_o[2] = {address_i[riscv::VLEN-1:3], 3'b110};
                     if (instr_is_compressed[3]) begin
                         // | * | C | C |   I   |
                         valid_o[2] = valid_i;
@@ -254,7 +254,7 @@ module instr_realign (
                     // | * |   I   | C | x  -> aligned
                     // |   I   | C | C | x  -> again unaligned
                     // | * | C | C | C | x  -> aligned
-                    addr_o[0] = {address_i[63:3], 3'b010};
+                    addr_o[0] = {address_i[riscv::VLEN-1:3], 3'b010};
 
                     if (instr_is_compressed[1]) begin
                         instr_o[0] = {16'b0, data_i[31:16]};
@@ -263,10 +263,10 @@ module instr_realign (
                         if (instr_is_compressed[2]) begin
                             valid_o[1] = valid_i;
                             instr_o[1] = {16'b0, data_i[47:32]};
-                            addr_o[1] = {address_i[63:3], 3'b100};
+                            addr_o[1] = {address_i[riscv::VLEN-1:3], 3'b100};
                             if (instr_is_compressed[3]) begin
                                 instr_o[2] = {16'b0, data_i[63:48]};
-                                addr_o[2] = {address_i[63:3], 3'b110};
+                                addr_o[2] = {address_i[riscv::VLEN-1:3], 3'b110};
                                 valid_o[2] = valid_i;
                             end else begin
                                 // this instruction is unaligned
@@ -276,14 +276,14 @@ module instr_realign (
                             end
                         end else begin
                             instr_o[1] = data_i[63:32];
-                            addr_o[1] = {address_i[63:3], 3'b100};
+                            addr_o[1] = {address_i[riscv::VLEN-1:3], 3'b100};
                             valid_o[1] = valid_i;
                         end
                     // instruction 1 is not compressed -> check slot 3
                     end else begin
                         instr_o[0] = data_i[47:16];
                         valid_o[0] = valid_i;
-                        addr_o[1] = {address_i[63:3], 3'b110};
+                        addr_o[1] = {address_i[riscv::VLEN-1:3], 3'b110};
                         if (instr_is_compressed[3]) begin
                             instr_o[1] = data_i[63:48];
                             valid_o[1] = valid_i;
@@ -311,7 +311,7 @@ module instr_realign (
                         // regular instruction -> unaligned
                         end else begin
                             unaligned_d = 1'b1;
-                            unaligned_address_d = {address_i[63:3], 3'b110};
+                            unaligned_address_d = {address_i[riscv::VLEN-1:3], 3'b110};
                             unaligned_instr_d = data_i[63:48];
                         end
                     // instruction is a regular instruction
@@ -327,7 +327,7 @@ module instr_realign (
                     valid_o = '0;
                     if (!instr_is_compressed[3]) begin
                         unaligned_d = 1'b1;
-                        unaligned_address_d = {address_i[63:3], 3'b110};
+                        unaligned_address_d = {address_i[riscv::VLEN-1:3], 3'b110};
                         unaligned_instr_d = data_i[63:48];
                     end else begin
                         valid_o[3] = valid_i;

--- a/src/issue_read_operands.sv
+++ b/src/issue_read_operands.sv
@@ -41,7 +41,7 @@ module issue_read_operands #(
     input  fu_t [2**REG_ADDR_SIZE-1:0]             rd_clobber_fpr_i,
     // To FU, just single issue for now
     output fu_data_t                               fu_data_o,
-    output logic [63:0]                            pc_o,
+    output logic [riscv::VLEN-1:0]                 pc_o,
     output logic                                   is_compressed_instr_o,
     // ALU 1
     input  logic                                   flu_ready_i,      // Fixed latency unit ready to accept a new request
@@ -214,7 +214,7 @@ module issue_read_operands #(
 
         // use the PC as operand a
         if (issue_instr_i.use_pc) begin
-            operand_a_n = issue_instr_i.pc;
+            operand_a_n = {{64-riscv::VLEN{1'b0}}, issue_instr_i.pc};
         end
 
         // use the zimm as operand a

--- a/src/issue_read_operands.sv
+++ b/src/issue_read_operands.sv
@@ -214,7 +214,7 @@ module issue_read_operands #(
 
         // use the PC as operand a
         if (issue_instr_i.use_pc) begin
-            operand_a_n = {{64-riscv::VLEN{1'b0}}, issue_instr_i.pc};
+            operand_a_n = {{64-riscv::VLEN{issue_instr_i.pc[riscv::VLEN-1]}}, issue_instr_i.pc};
         end
 
         // use the zimm as operand a

--- a/src/issue_stage.sv
+++ b/src/issue_stage.sv
@@ -33,7 +33,7 @@ module issue_stage #(
     output logic                                     decoded_instr_ack_o,
     // to EX
     output fu_data_t                                 fu_data_o,
-    output logic [63:0]                              pc_o,
+    output logic [riscv::VLEN-1:0]                   pc_o,
     output logic                                     is_compressed_instr_o,
     input  logic                                     flu_ready_i,
     output logic                                     alu_valid_o,

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -82,21 +82,21 @@ module load_store_unit #(
     // Address Generation Unit (AGU)
     // ------------------------------
     // virtual address as calculated by the AGU in the first cycle
-    logic [63:0] vaddr_i;
-    logic [7:0]  be_i;
+    logic [riscv::VLEN-1:0]   vaddr_i;
+    logic [7:0]               be_i;
 
-    assign vaddr_i = $unsigned($signed(fu_data_i.imm) + $signed(fu_data_i.operand_a));
+    assign vaddr_i = $unsigned($signed(fu_data_i.imm[riscv::VLEN-1:0]) + $signed(fu_data_i.operand_a[riscv::VLEN-1:0]));
 
     logic                     st_valid_i;
     logic                     ld_valid_i;
     logic                     ld_translation_req;
     logic                     st_translation_req;
-    logic [63:0]              ld_vaddr;
-    logic [63:0]              st_vaddr;
+    logic [riscv::VLEN-1:0]   ld_vaddr;
+    logic [riscv::VLEN-1:0]   st_vaddr;
     logic                     translation_req;
     logic                     translation_valid;
-    logic [63:0]              mmu_vaddr;
-    logic [63:0]              mmu_paddr;
+    logic [riscv::VLEN-1:0]   mmu_vaddr;
+    logic [riscv::PLEN-1:0]   mmu_paddr;
     exception_t               mmu_exception;
     logic                     dtlb_hit;
 
@@ -234,7 +234,7 @@ module load_store_unit #(
         st_valid_i = 1'b0;
 
         translation_req      = 1'b0;
-        mmu_vaddr            = 64'b0;
+        mmu_vaddr            = {riscv::VLEN{1'b0}};
 
         // check the operator to activate the right functional unit accordingly
         unique case (lsu_ctrl.fu)
@@ -318,33 +318,33 @@ module load_store_unit #(
             if (lsu_ctrl.fu == LOAD) begin
                 misaligned_exception = {
                     riscv::LD_ADDR_MISALIGNED,
-                    lsu_ctrl.vaddr,
+                    {{64-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
                     1'b1
                 };
 
             end else if (lsu_ctrl.fu == STORE) begin
                 misaligned_exception = {
                     riscv::ST_ADDR_MISALIGNED,
-                    lsu_ctrl.vaddr,
+                    {{64-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
                     1'b1
                 };
             end
         end
 
-        // we work with SV39, so if VM is enabled, check that all bits [63:38] are equal
-        if (en_ld_st_translation_i && !((&lsu_ctrl.vaddr[63:38]) == 1'b1 || (|lsu_ctrl.vaddr[63:38]) == 1'b0)) begin
+        // we work with SV39, so if VM is enabled, check that all bits [riscv::VLEN-1:38] are equal
+        if (en_ld_st_translation_i && !((&lsu_ctrl.vaddr[riscv::VLEN-1:38]) == 1'b1 || (|lsu_ctrl.vaddr[riscv::VLEN-1:38]) == 1'b0)) begin
 
             if (lsu_ctrl.fu == LOAD) begin
                 misaligned_exception = {
                     riscv::LD_ACCESS_FAULT,
-                    lsu_ctrl.vaddr,
+                    {{64-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
                     1'b1
                 };
 
             end else if (lsu_ctrl.fu == STORE) begin
                 misaligned_exception = {
                     riscv::ST_ACCESS_FAULT,
-                    lsu_ctrl.vaddr,
+                    {{64-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
                     1'b1
                 };
             end

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -30,8 +30,8 @@ module load_unit (
     output exception_t               ex_o,
     // MMU -> Address Translation
     output logic                     translation_req_o,   // request address translation
-    output logic [63:0]              vaddr_o,             // virtual address out
-    input  logic [63:0]              paddr_i,             // physical address in
+    output logic [riscv::VLEN-1:0]   vaddr_o,             // virtual address out
+    input  logic [riscv::PLEN-1:0]   paddr_i,             // physical address in
     input  exception_t               ex_i,                // exception which may has happened earlier. for example: mis-aligned exception
     input  logic                     dtlb_hit_i,          // hit on the dtlb, send in the same cycle as the request
     // address checker

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -306,12 +306,12 @@ module mmu #(
                     // check if the page is write-able and we are not violating privileges
                     // also check if the dirty flag is set
                     if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},lsu_vaddr_q}, 1'b1};
+                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
                     end
 
                 // this is a load, check for sufficient access privileges - throw a page fault if necessary
                 end else if (daccess_err) begin
-                    lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},lsu_vaddr_q}, 1'b1};
+                    lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
                 end
             end else
 
@@ -326,9 +326,9 @@ module mmu #(
                     lsu_valid_o = 1'b1;
                     // the page table walker can only throw page faults
                     if (lsu_is_store_q) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},update_vaddr}, 1'b1};
+                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
                     end else begin
-                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},update_vaddr}, 1'b1};
+                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
                     end
                 end
             end

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -35,14 +35,14 @@ module mmu #(
         // in the LSU as we distinguish load and stores, what we do here is simple address translation
         input  exception_t                      misaligned_ex_i,
         input  logic                            lsu_req_i,        // request address translation
-        input  logic [63:0]                     lsu_vaddr_i,      // virtual address in
+        input  logic [riscv::VLEN-1:0]          lsu_vaddr_i,      // virtual address in
         input  logic                            lsu_is_store_i,   // the translation is requested by a store
         // if we need to walk the page table we can't grant in the same cycle
         // Cycle 0
         output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
         // Cycle 1
         output logic                            lsu_valid_o,      // translation is valid
-        output logic [63:0]                     lsu_paddr_o,      // translated address
+        output logic [riscv::PLEN-1:0]          lsu_paddr_o,      // translated address
         output exception_t                      lsu_exception_o,  // address translation threw an exception
         // General control signals
         input riscv::priv_lvl_t                 priv_lvl_i,
@@ -67,7 +67,7 @@ module mmu #(
     logic        walking_instr; // PTW is walking because of an ITLB miss
     logic        ptw_error;     // PTW threw an exception
 
-    logic [38:0] update_vaddr;
+    logic [riscv::VLEN-1:0] update_vaddr;
     tlb_update_t update_ptw_itlb, update_ptw_dtlb;
 
     logic        itlb_lu_access;
@@ -184,7 +184,7 @@ module mmu #(
     always_comb begin : instr_interface
         // MMU disabled: just pass through
         icache_areq_o.fetch_valid  = icache_areq_i.fetch_req;
-        icache_areq_o.fetch_paddr  = icache_areq_i.fetch_vaddr; // play through in case we disabled address translation
+        icache_areq_o.fetch_paddr  = icache_areq_i.fetch_vaddr[riscv::PLEN-1:0]; // play through in case we disabled address translation
         // two potential exception sources:
         // 1. HPTW threw an exception -> signal with a page fault exception
         // 2. We got an access error because of insufficient permissions -> throw an access exception
@@ -198,9 +198,9 @@ module mmu #(
         // AXI decode error), or when PTW performs walk due to ITLB miss and raises
         // an error.
         if (enable_translation_i) begin
-            // we work with SV39, so if VM is enabled, check that all bits [63:38] are equal
-            if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[63:38]) == 1'b1 || (|icache_areq_i.fetch_vaddr[63:38]) == 1'b0)) begin
-                icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, icache_areq_i.fetch_vaddr, 1'b1};
+            // we work with SV39, so if VM is enabled, check that all bits [riscv::VLEN-1:38] are equal
+            if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:38]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:38]) == 1'b0)) begin
+                icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{64-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
             end
 
             icache_areq_o.fetch_valid = 1'b0;
@@ -225,7 +225,7 @@ module mmu #(
                 // we got an access error
                 if (iaccess_err) begin
                     // throw a page fault
-                    icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, icache_areq_i.fetch_vaddr, 1'b1};
+                    icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{64-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
                 end
             end else
             // ---------
@@ -234,22 +234,22 @@ module mmu #(
             // watch out for exceptions happening during walking the page table
             if (ptw_active && walking_instr) begin
                 icache_areq_o.fetch_valid = ptw_error;
-                icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
+                icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{64-riscv::VLEN{1'b0}}, update_vaddr}, 1'b1};
             end
         end
         // if it didn't match any execute region throw an `Instruction Access Fault`
         if (!match_any_execute_region) begin
-          icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, icache_areq_o.fetch_paddr, 1'b1};
+          icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr}, 1'b1};
         end
     end
 
     // check for execute flag on memory
-    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, icache_areq_o.fetch_paddr);
+    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     //-----------------------
     // Data Interface
     //-----------------------
-    logic [63:0] lsu_vaddr_n,     lsu_vaddr_q;
+    logic [riscv::VLEN-1:0] lsu_vaddr_n,     lsu_vaddr_q;
     riscv::pte_t dtlb_pte_n,      dtlb_pte_q;
     exception_t  misaligned_ex_n, misaligned_ex_q;
     logic        lsu_req_n,       lsu_req_q;
@@ -273,7 +273,7 @@ module mmu #(
         dtlb_is_2M_n          = dtlb_is_2M;
         dtlb_is_1G_n          = dtlb_is_1G;
 
-        lsu_paddr_o           = lsu_vaddr_q;
+        lsu_paddr_o           = lsu_vaddr_q[riscv::PLEN-1:0];
         lsu_valid_o           = lsu_req_q;
         lsu_exception_o       = misaligned_ex_q;
         // mute misaligned exceptions if there is no request otherwise they will throw accidental exceptions
@@ -306,12 +306,12 @@ module mmu #(
                     // check if the page is write-able and we are not violating privileges
                     // also check if the dirty flag is set
                     if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, lsu_vaddr_q, 1'b1};
+                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},lsu_vaddr_q}, 1'b1};
                     end
 
                 // this is a load, check for sufficient access privileges - throw a page fault if necessary
                 end else if (daccess_err) begin
-                    lsu_exception_o = {riscv::LOAD_PAGE_FAULT, lsu_vaddr_q, 1'b1};
+                    lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},lsu_vaddr_q}, 1'b1};
                 end
             end else
 
@@ -326,9 +326,9 @@ module mmu #(
                     lsu_valid_o = 1'b1;
                     // the page table walker can only throw page faults
                     if (lsu_is_store_q) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
+                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},update_vaddr}, 1'b1};
                     end else begin
-                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
+                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{64-riscv::VLEN{1'b0}},update_vaddr}, 1'b1};
                     end
                 end
             end

--- a/src/ptw.sv
+++ b/src/ptw.sv
@@ -40,18 +40,18 @@ module ptw #(
     output tlb_update_t             itlb_update_o,
     output tlb_update_t             dtlb_update_o,
 
-    output logic [38:0]             update_vaddr_o,
+    output logic [riscv::VLEN-1:0]  update_vaddr_o,
 
     input  logic [ASID_WIDTH-1:0]   asid_i,
     // from TLBs
     // did we miss?
     input  logic                    itlb_access_i,
     input  logic                    itlb_hit_i,
-    input  logic [63:0]             itlb_vaddr_i,
+    input  logic [riscv::VLEN-1:0]  itlb_vaddr_i,
 
     input  logic                    dtlb_access_i,
     input  logic                    dtlb_hit_i,
-    input  logic [63:0]             dtlb_vaddr_i,
+    input  logic [riscv::VLEN-1:0]  dtlb_vaddr_i,
     // from CSR file
     input  logic [43:0]             satp_ppn_i, // ppn from satp
     input  logic                    mxr_i,
@@ -89,7 +89,7 @@ module ptw #(
     // register the ASID
     logic [ASID_WIDTH-1:0]  tlb_update_asid_q, tlb_update_asid_n;
     // register the VPN we need to walk, SV39 defines a 39 bit virtual address
-    logic [63:0] vaddr_q,   vaddr_n;
+    logic [riscv::VLEN-1:0] vaddr_q,   vaddr_n;
     // 4 byte aligned physical pointer
     logic[55:0] ptw_pptr_q, ptw_pptr_n;
 

--- a/src/store_buffer.sv
+++ b/src/store_buffer.sv
@@ -33,7 +33,7 @@ module store_buffer (
     input  logic         valid_i,         // this is a valid store
     input  logic         valid_without_flush_i, // just tell if the address is valid which we are current putting and do not take any further action
 
-    input  logic [63:0]  paddr_i,         // physical address of store which needs to be placed in the queue
+    input  logic [riscv::PLEN-1:0]  paddr_i,         // physical address of store which needs to be placed in the queue
     input  logic [63:0]  data_i,          // data which is placed in the queue
     input  logic [7:0]   be_i,            // byte enable in
     input  logic [1:0]   data_size_i,     // type of request we are making (e.g.: bytes to write)
@@ -47,11 +47,11 @@ module store_buffer (
     // 1. Speculative queue
     // 2. Commit queue which is non-speculative, e.g.: the store will definitely happen.
     struct packed {
-        logic [63:0] address;
-        logic [63:0] data;
-        logic [7:0]  be;
-        logic [1:0]  data_size;
-        logic        valid;     // this entry is valid, we need this for checking if the address offset matches
+        logic [riscv::PLEN-1:0] address;
+        logic [63:0]            data;
+        logic [7:0]             be;
+        logic [1:0]             data_size;
+        logic                   valid;     // this entry is valid, we need this for checking if the address offset matches
     } speculative_queue_n [DEPTH_SPEC-1:0], speculative_queue_q [DEPTH_SPEC-1:0],
       commit_queue_n [DEPTH_COMMIT-1:0],    commit_queue_q [DEPTH_COMMIT-1:0];
 

--- a/src/store_unit.sv
+++ b/src/store_unit.sv
@@ -33,8 +33,8 @@ module store_unit (
     output exception_t               ex_o,
     // MMU -> Address Translation
     output logic                     translation_req_o, // request address translation
-    output logic [63:0]              vaddr_o,           // virtual address out
-    input  logic [63:0]              paddr_i,           // physical address in
+    output logic [riscv::VLEN-1:0]   vaddr_o,           // virtual address out
+    input  logic [riscv::PLEN-1:0]   paddr_i,           // physical address in
     input  exception_t               ex_i,
     input  logic                     dtlb_hit_i,       // will be one in the same cycle translation_req was asserted if it hits
     // address checker

--- a/src/tlb.sv
+++ b/src/tlb.sv
@@ -28,7 +28,7 @@ module tlb #(
     // Lookup signals
     input  logic                    lu_access_i,
     input  logic [ASID_WIDTH-1:0]   lu_asid_i,
-    input  logic [63:0]             lu_vaddr_i,
+    input  logic [riscv::VLEN-1:0]  lu_vaddr_i,
     output riscv::pte_t             lu_content_o,
     output logic                    lu_is_2M_o,
     output logic                    lu_is_1G_o,

--- a/src/util/ex_trace_item.svh
+++ b/src/util/ex_trace_item.svh
@@ -15,12 +15,12 @@
 `ifndef VERILATOR
 class ex_trace_item;
     // contains a human readable form of the cause value
-    string       cause_s;
-    logic [63:0] cause;
-    logic [63:0] tval;
-    logic [63:0] pc;
+    string                  cause_s;
+    logic [63:0]            cause;
+    logic [63:0]            tval;
+    logic [riscv::VLEN-1:0] pc;
 
-    function new (logic [63:0] pc, logic [63:0] cause, logic [63:0] tval);
+    function new (logic [riscv::VLEN-1:0] pc, logic [63:0] cause, logic [63:0] tval);
 
         this.cause = cause;
 

--- a/src/util/instr_trace_item.svh
+++ b/src/util/instr_trace_item.svh
@@ -37,7 +37,7 @@ class instr_trace_item;
     logic              result_fpr [$];
     logic [63:0]       imm;
     logic [63:0]       result;
-    logic [63:0]       paddr;
+    logic [riscv::PLEN-1:0]       paddr;
     string             priv_lvl;
     ariane_pkg::bp_resolve_t       bp;
 
@@ -45,7 +45,7 @@ class instr_trace_item;
 
     // constructor creating a new instruction trace item, e.g.: a single instruction with all relevant information
     function new (time simtime, longint unsigned cycle, ariane_pkg::scoreboard_entry_t sbe, logic [31:0] instr, logic [63:0] gp_reg_file [32],
-                logic [63:0] fp_reg_file [32], logic [63:0] result, logic [63:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
+                logic [63:0] fp_reg_file [32], logic [63:0] result, logic [riscv::PLEN-1:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
         this.simtime  = simtime;
         this.cycle    = cycle;
         this.pc       = sbe.pc;
@@ -409,7 +409,7 @@ class instr_trace_item;
             instr_tracer_pkg::FSW,
             instr_tracer_pkg::FSD,
             instr_tracer_pkg::FSQ: begin
-                logic [63:0] vaddress = gp_reg_file[read_regs[1]] + this.imm;
+                logic [riscv::VLEN-1:0] vaddress = gp_reg_file[read_regs[1]] + this.imm;
                 s = $sformatf("%s VA: %x PA: %x", s, vaddress, this.paddr);
             end
 
@@ -431,7 +431,7 @@ class instr_trace_item;
             instr_tracer_pkg::FLW,
             instr_tracer_pkg::FLD,
             instr_tracer_pkg::FLQ: begin
-                logic [63:0] vaddress = gp_reg_file[read_regs[0]] + this.imm;
+                logic [riscv::VLEN-1:0] vaddress = gp_reg_file[read_regs[0]] + this.imm;
                 s = $sformatf("%s VA: %x PA: %x", s, vaddress, this.paddr);
             end
         endcase

--- a/src/util/instr_tracer.sv
+++ b/src/util/instr_tracer.sv
@@ -186,7 +186,7 @@ module instr_tracer (
   endfunction
 
   // pragma translate_off
-  function void printInstr(ariane_pkg::scoreboard_entry_t sbe, logic [31:0] instr, logic [63:0] result, logic [63:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
+  function void printInstr(ariane_pkg::scoreboard_entry_t sbe, logic [31:0] instr, logic [63:0] result, logic [riscv::PLEN-1:0] paddr, riscv::priv_lvl_t priv_lvl, logic debug_mode, ariane_pkg::bp_resolve_t bp);
     automatic instr_trace_item iti = new ($time, clk_ticks, sbe, instr, gp_reg_file, fp_reg_file, result, paddr, priv_lvl, debug_mode, bp);
     // print instruction to console
     automatic string print_instr = iti.printInstr();
@@ -197,7 +197,7 @@ module instr_tracer (
     $fwrite(f, {print_instr, "\n"});
   endfunction
 
-  function void printException(logic [63:0] pc, logic [63:0] cause, logic [63:0] tval);
+  function void printException(logic [riscv::VLEN-1:0] pc, logic [63:0] cause, logic [63:0] tval);
     automatic ex_trace_item eti = new (pc, cause, tval);
     automatic string print_ex = eti.printException();
     uvm_report_info( "Tracer",  print_ex, UVM_HIGH);

--- a/src/util/instr_tracer_if.sv
+++ b/src/util/instr_tracer_if.sv
@@ -39,12 +39,12 @@ interface instr_tracer_if (
     logic                          [1:0] commit_ack;
     // address translation
     // stores
-    logic              st_valid;
-    logic [63:0]       st_paddr;
+    logic                         st_valid;
+    logic [riscv::PLEN-1:0]       st_paddr;
     // loads
-    logic              ld_valid;
-    logic              ld_kill;
-    logic [63:0]       ld_paddr;
+    logic                         ld_valid;
+    logic                         ld_kill;
+    logic [riscv::PLEN-1:0]       ld_paddr;
     // misprediction
     ariane_pkg::bp_resolve_t resolve_branch;
     // exceptions


### PR DESCRIPTION
**Why to request a pull for this modification?**
In RISCV specification, two types of address are defined: physical and virtual address. Physical address is max 56 bits and virtual address is 39bit (sv39) or 48bits (sv48).
In Ariane implementation, physical and virtual addresses are implemented on 56 and 64bits.
Address length has impact on a lot of functionalities, scoreboard or caches for instance. By implementing two RTL variables, PLEN (as physical length) and VLEN (as virtual length), address length becomes configurable. By setting PLEN=32 and VLEN=39, kgate reduction is about 40kgates.
I think it would be nice to integrate such a modification in main line to stick to the RISCV specification and reduce the gate count.

**Modification:**
-	Only Ariane has been modified, not testbench. No impact on Ariane IOs.
-	36 files have been modified.
-	As STD_CACHE is deprecated, it has not been modified. Keep the original configuration (VLEN=64 and PLEN=56) when using STD_CACHE.
-      The following constraint must be met: PLEN > VLEN
-	Regression suite is PASS when VLEN/PLEN=64/56 and 39/32.
-	Test traces have been compare cycle by cycle. No discrepancy has been detected between before and after modification.
-	No additional Verilator warnings due to this modification
-	Synthesis shows a 10% of gate reduction.

++,
Jean-Roch
