### PR TITLE
Fix Linux RTC deviation

### DIFF
--- a/fpga/src/bootrom/ariane.dts
+++ b/fpga/src/bootrom/ariane.dts
@@ -11,7 +11,7 @@
   cpus {
     #address-cells = <1>;
     #size-cells = <0>;
-    timebase-frequency = <15000000>; // 15 MHz
+    timebase-frequency = <25000000>; // 25 MHz
     CPU0: cpu@0 {
       clock-frequency = <50000000>; // 50 MHz
       device_type = "cpu";


### PR DESCRIPTION
The default clock frequency is 50MHz as also noted by the [device tree file](https://github.com/pulp-platform/ariane/blob/ad70ce1f30dad539e5a365ffe71a02aaf20b397e/fpga/src/bootrom/ariane.dts#L16).

The rtc is generated by 
https://github.com/pulp-platform/ariane/blob/ad70ce1f30dad539e5a365ffe71a02aaf20b397e/fpga/src/ariane_xilinx.sv#L441-L451
which, as noted, halves the clock frequency, i.e. to 25MHz.

The current device tree specifies the timebase-frequency to be 15MHz
https://github.com/pulp-platform/ariane/blob/ad70ce1f30dad539e5a365ffe71a02aaf20b397e/fpga/src/bootrom/ariane.dts#L14

Using a build of ariane-sdk and running e.g. `sleep 30` show that time based operations have about a 30 to 40% error to them, i.e. the sleep example will take only about 19 second.