### PR TITLE
Proposal for protection from accessing missing physical memory regions

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -47,6 +47,9 @@ package ariane_pkg;
       int unsigned                      NrCachedRegionRules;   // Number of regions which have cached property
       logic [NrMaxRules-1:0][63:0]      CachedRegionAddrBase;  // base which needs to match
       logic [NrMaxRules-1:0][63:0]      CachedRegionLength;    // bit mask which bits to consider when matching the rule
+      int unsigned                      NrPhysicalRegionRules;   // Number of regions which have physical memory present
+      logic [NrMaxRules-1:0][63:0]      PhysicalRegionAddrBase;  // base which needs to match
+      logic [NrMaxRules-1:0][63:0]      PhysicalRegionLength;    // bit mask which bits to consider when matching the rule
       // cache config
       bit                               Axi64BitCompliant;     // set to 1 when using in conjunction with 64bit AXI bus adapter
       bit                               SwapEndianess;         // set to 1 to swap endianess inside L1.5 openpiton adapter
@@ -65,11 +68,15 @@ package ariane_pkg;
       NrExecuteRegionRules: 3,
       //                      DRAM,          Boot ROM,   Debug Module
       ExecuteRegionAddrBase: {64'h8000_0000, 64'h1_0000, 64'h0},
-      ExecuteRegionLength:   {64'h40000000,  64'h10000,  64'h1000},
+      ExecuteRegionLength:   {64'h4000_0000, 64'h1_0000, 64'h1000},
       // cached region
       NrCachedRegionRules:    1,
       CachedRegionAddrBase:  {64'h8000_0000},
       CachedRegionLength:    {64'h40000000},
+      // physical region
+      NrPhysicalRegionRules:    1,
+      PhysicalRegionAddrBase:  {64'h0000_0000},
+      PhysicalRegionLength:    {64'hC000_0000},
       //  cache config
       Axi64BitCompliant:      1'b1,
       SwapEndianess:          1'b0,
@@ -87,6 +94,7 @@ package ariane_pkg;
         assert(Cfg.NrNonIdempotentRules <= NrMaxRules);
         assert(Cfg.NrExecuteRegionRules <= NrMaxRules);
         assert(Cfg.NrCachedRegionRules  <= NrMaxRules);
+        assert(Cfg.NrPhysicalRegionRules  <= NrMaxRules);
       `endif
       // pragma translate_on
     endfunction
@@ -123,6 +131,15 @@ package ariane_pkg;
       end
       return |pass;
     endfunction : is_inside_cacheable_regions
+
+    function automatic logic is_inside_physical_regions (ariane_cfg_t Cfg, logic[63:0] address);
+      automatic logic[NrMaxRules-1:0] pass;
+      pass = '0;
+      for (int unsigned k = 0; k < Cfg.NrPhysicalRegionRules; k++) begin
+        pass[k] = range_check(Cfg.PhysicalRegionAddrBase[k], Cfg.PhysicalRegionLength[k], address);
+      end
+      return |pass;
+    endfunction : is_inside_physical_regions
 
     // TODO: Slowly move those parameters to the new system.
     localparam NR_SB_ENTRIES = 8; // number of scoreboard entries

--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -289,6 +289,7 @@ package riscv;
     localparam logic [63:0] ENV_CALL_MMODE        = 11; // environment call from machine mode
     localparam logic [63:0] INSTR_PAGE_FAULT      = 12; // Instruction page fault
     localparam logic [63:0] LOAD_PAGE_FAULT       = 13; // Load page fault
+    localparam logic [63:0] PHYSICAL_PROT_FAULT   = 14; // Physical protection fault (non-standard)
     localparam logic [63:0] STORE_PAGE_FAULT      = 15; // Store page fault
     localparam logic [63:0] DEBUG_REQUEST         = 24; // Debug request
 

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -257,6 +257,7 @@ module mmu #(
     logic        dtlb_hit_n,      dtlb_hit_q;
     logic        dtlb_is_2M_n,    dtlb_is_2M_q;
     logic        dtlb_is_1G_n,    dtlb_is_1G_q;
+    logic match_any_physical_region;
 
     // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
     assign lsu_dtlb_hit_o = (en_ld_st_translation_i) ? dtlb_lu_hit :  1'b1;
@@ -331,9 +332,17 @@ module mmu #(
                         lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {25'b0, update_vaddr}, 1'b1};
                     end
                 end
+            end // if (ptw_active && !walking_instr)
             end
+        // if it didn't match any physical region throw a (non-standard) `Physical Protection Fault`
+        if (lsu_valid_o && !match_any_physical_region) begin
+          lsu_exception_o = {riscv::PHYSICAL_PROT_FAULT, lsu_paddr_o, 1'b1};
         end
     end
+
+    // check for physical memory presence
+    assign match_any_physical_region = ariane_pkg::is_inside_physical_regions(ArianeCfg, lsu_paddr_o);
+
     // ----------
     // Registers
     // ----------

--- a/tb/ariane_soc_pkg.sv
+++ b/tb/ariane_soc_pkg.sv
@@ -74,16 +74,20 @@ package ariane_soc;
     BTBEntries: 32,
     BHTEntries: 128,
     // idempotent region
-    NrNonIdempotentRules:  1,
-    NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {DRAMBase},
-    NrExecuteRegionRules:  3,
-    ExecuteRegionAddrBase: {DRAMBase,   ROMBase,   DebugBase},
-    ExecuteRegionLength:   {DRAMLength, ROMLength, DebugLength},
+    NrNonIdempotentRules:   1,
+    NonIdempotentAddrBase:  {64'b0},
+    NonIdempotentLength:    {DRAMBase},
+    NrExecuteRegionRules:   3,
+    ExecuteRegionAddrBase:  {DRAMBase,   ROMBase,   DebugBase},
+    ExecuteRegionLength:    {DRAMLength, ROMLength, DebugLength},
     // cached region
     NrCachedRegionRules:    1,
-    CachedRegionAddrBase:  {DRAMBase},
-    CachedRegionLength:    {DRAMLength},
+    CachedRegionAddrBase:   {DRAMBase},
+    CachedRegionLength:     {DRAMLength},
+    // physical region
+    NrPhysicalRegionRules:  1,
+    PhysicalRegionAddrBase: {64'b0},
+    PhysicalRegionLength:   {DRAMBase+DRAMLength},
     //  cache config
     Axi64BitCompliant:      1'b1,
     SwapEndianess:          1'b0,


### PR DESCRIPTION
At the moment Ariane can encounter a fatal error if it accesses a non-existent physical region. Neither does it support the ability of the AXI bus to return an error due to non-existence of memory. This proposal introduces an extra layer of protection that traps if non-existent memory is accessed, before generating an AXI transaction. This brings the behaviour roughly into line with what Rocket does.
