### PR TITLE
According to SV standard only unpacked structures have an implementat…

### DIFF
--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -631,7 +631,7 @@ package riscv;
     endfunction
     // pragma translate_on
 
-    typedef struct packed {
+    typedef struct {
         byte priv;
         longint unsigned pc;
         byte is_fp;


### PR DESCRIPTION
…ion-dependent packing, normally matching the C compiler