### PR TITLE
Add conditional Rocket Chip traceport to top-level

### DIFF
--- a/LICENSE.Berkeley
+++ b/LICENSE.Berkeley
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2017-2020, The Regents of the University of California (Regents)
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/include/traced_instr_pkg.sv
+++ b/include/traced_instr_pkg.sv
@@ -1,0 +1,22 @@
+// Author: Abraham Gonzalez, UC Berkeley
+// Date: 24.02.2020
+// Description: Traced Instruction and Port (using in Rocket Chip based systems)
+
+package traced_instr_pkg;
+
+  typedef struct packed {
+      logic clock;
+      logic reset;
+      logic valid;
+      logic [63:0] iaddr;
+      logic [31:0] insn;
+      logic [1:0] priv;
+      logic exception;
+      logic interrupt;
+      logic [63:0] cause;
+      logic [63:0] tval;
+  } traced_instr_t;
+
+  typedef traced_instr_t [ariane_pkg::NR_COMMIT_PORTS-1:0] trace_port_t;
+
+endpackage

--- a/include/traced_instr_pkg.sv
+++ b/include/traced_instr_pkg.sv
@@ -1,3 +1,5 @@
+// See LICENSE.Berkeley for license details.
+
 // Author: Abraham Gonzalez, UC Berkeley
 // Date: 24.02.2020
 // Description: Traced Instruction and Port (using in Rocket Chip based systems)

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -671,12 +671,12 @@ module ariane #(
   for (genvar i = 0; i < NR_COMMIT_PORTS; i++) begin : gen_tp_connect
     assign trace_o[i].clock = clk_i;
     assign trace_o[i].reset = rst_ni;
-    assign trace_o[i].valid = commit_ack[i] && !commit_instr_id_commit[i].ex.valid;
+    assign trace_o[i].valid = commit_ack[i] & ~commit_instr_id_commit[i].ex.valid;
     assign trace_o[i].iaddr = commit_instr_id_commit[i].pc;
     assign trace_o[i].insn = commit_instr_id_commit[i].ex.tval[31:0];
     assign trace_o[i].priv = priv_lvl;
-    assign trace_o[i].exception = commit_ack[i] && commit_instr_id_commit[i].ex.valid && !commit_instr_id_commit[i].ex.cause[63];
-    assign trace_o[i].interrupt = commit_ack[i] && commit_instr_id_commit[i].ex.valid && commit_instr_id_commit[i].ex.cause[63];
+    assign trace_o[i].exception = commit_ack[i] & commit_instr_id_commit[i].ex.valid & ~commit_instr_id_commit[i].ex.cause[63];
+    assign trace_o[i].interrupt = commit_ack[i] & commit_instr_id_commit[i].ex.valid & commit_instr_id_commit[i].ex.cause[63];
     assign trace_o[i].cause = commit_instr_id_commit[i].ex.cause;
     assign trace_o[i].tval = commit_instr_id_commit[i].ex.tval[31:0];
   end
@@ -820,4 +820,3 @@ module ariane #(
 //pragma translate_on
 
 endmodule // ariane
-


### PR DESCRIPTION
This is part of the broader work being done to integrate Ariane into Chipyard (see https://github.com/ucb-bar/chipyard/pull/448).

Add a trace port to the top-level Ariane IOs. This matches the format given by https://github.com/chipsalliance/rocket-chip/blob/5e506e3923c6935502b3d80afb57e329609cb326/src/main/scala/rocket/CSR.scala#L163-L172. This allows Ariane to hook up to FireSim's TracerV interface (https://docs.fires.im/en/dev/Advanced-Usage/Debugging-and-Profiling-on-FPGA/TracerV.html).

Any comments or feedback would be greatly appreciated!