### PR TITLE
Removed the check in c.fldsp against ft0 destination

### DIFF
--- a/src/compressed_decoder.sv
+++ b/src/compressed_decoder.sv
@@ -202,7 +202,6 @@ module compressed_decoder
                     riscv::OpcodeC2Fldsp: begin
                         // c.fldsp -> fld rd, imm(x2)
                         instr_o = {3'b0, instr_i[4:2], instr_i[12], instr_i[6:5], 3'b000, 5'h02, 3'b011, instr_i[11:7], riscv::OpcodeLoadFp};
-                        if (instr_i[11:7] == 5'b0)  illegal_instr_o = 1'b1;
                     end
 
                     riscv::OpcodeC2Lwsp: begin


### PR DESCRIPTION
PR for issue #381 

If a compressed instruction fld rd, xxx(sp) use ft0 as rd, currently Ariane will generate an illegal instruction fault. However, the restriction that destination shouldn't be zero should only be applied to GPR; floating point register ft0 is not hard-wired to zero and can be used as destination.

This pull request removed the check in compressed decoder that causes this issue.