### PR TITLE
Adding mcounteren and scounteren registers

### DIFF
--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -849,7 +849,7 @@ module csr_regfile #(
             end
             // check counter-enabled counter CSR accesses
             // counter address range is C00 to C1F
-            if (csr_addr_i[11:5] == 7'b1100000) begin
+            if (csr_addr_i inside {[riscv::CSR_CYCLE:riscv::CSR_HPM_COUNTER_31]}) begin
                 unique case (csr_addr.csr_decode.priv_lvl)
                     riscv::PRIV_LVL_M: privilege_violation = 1'b0;
                     riscv::PRIV_LVL_S: privilege_violation = ~mcounteren_q[csr_addr_i[4:0]];


### PR DESCRIPTION
Wanted to address some interest in having `rdcycle` in S and U modes since the privileged spec allows this kind of delegation. Unfortunately I don't have a very minimal test case for this to check both modes, but I can see that the previous illegal access exceptions no longer appear when using `rdcycle` provided that `mcounteren`/`scounteren` have the right values.

Probably needs some further testing.

Also the changes I made are all in csr_regfile.sv. I don't know what changes need to be done to enable readtime to work properly, too.