### PR TITLE
Fix to enable verilator variable to point to Verilator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BOARD          ?= genesys2
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 root-dir := $(dir $(mkfile_path))
 
-support_verilator_4 := $(shell (verilator --version | grep '4\.') &> /dev/null; echo $$?)
+support_verilator_4 := $(shell ($(verilator) --version | grep '4\.') &> /dev/null; echo $$?)
 ifeq ($(support_verilator_4), 0)
 	verilator_threads := 2
 endif


### PR DESCRIPTION
The Makefile was setup to allow setting "make verilator=..." however missed a usage so it didn't actually work.  This fixes it.

BTW thanks for using Verilator with your project!
