### PR TITLE
fpu: Bump to release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Fix non-setable MEIE bit in MIE CSR
+- Bump `fpnew` to `v0.6.2`
 
 ### 4.2.0 - 2019-06-04
 


### PR DESCRIPTION
Among other things, this fixes VCS simulation issues for F2F casts.